### PR TITLE
Integrate OCR fallback, batch scanning, and richer exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.iml
+.gradle/
+/local.properties
+/.idea/
+.DS_Store
+/build/
+/captures/
+.externalNativeBuild/
+.cxx/
+app/build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,187 @@
-# Sirim-v2
+# SIRIM QR Code Scanner MVP Plan
+
+## Overview
+- **Target Platform:** Android 13+ (API Level 33+)
+- **Purpose:** First prototype for SIRIM QR code recognition operating fully offline.
+
+## Getting Started
+
+The repository now contains a full Android Studio project that implements the MVP described below. The project lives in the `app` module and is built with Kotlin, Jetpack Compose, CameraX, ML Kit, Room, and the export libraries discussed in the plan.
+
+### Prerequisites
+- Android Studio Giraffe (or newer) with Android SDK 34 installed.
+- A device or emulator running Android 13 (API 33) or later with camera capabilities for end-to-end scanning tests.
+
+### Build & Run
+1. Open the project root (`Sirim-v2`) in Android Studio.
+2. Sync Gradle when prompted and let the IDE download dependencies (ML Kit models download on first run at build time).
+3. Connect an Android 13+ device or start an emulator.
+4. Use **Run ▶ Run 'app'** to install and launch the application. Log in with `admin / admin`.
+
+### OCR Fallback Setup
+- The ML Kit recogniser handles most captures, but the app also ships with a Tesseract fallback. Place the English trained data file at `app/src/main/assets/tessdata/eng.traineddata` (or push it to the device's `/files/tesseract/tessdata` directory) to enable the fallback path. Without this file the app will gracefully fall back to ML Kit only.
+
+### Testing Notes
+- Unit/UI tests are scaffolded via the default Gradle tasks (`./gradlew test`, `./gradlew connectedAndroidTest`). They currently serve as placeholders until bespoke tests are implemented for the MVP.
+- OCR and camera functionality should be validated on physical hardware for accurate results.
+
+## Project Structure Highlights
+
+```
+app/
+ ├── build.gradle.kts           # Android app configuration and dependencies
+ ├── src/main/
+ │   ├── AndroidManifest.xml    # Declares permissions, provider, and MainActivity
+ │   ├── java/com/sirim/scanner
+ │   │   ├── data                # Room database, repositories, OCR helpers, export manager
+ │   │   ├── ui                  # Compose screens (login, dashboard, scanner, records, export)
+ │   │   ├── MainActivity.kt     # Compose navigation host
+ │   │   └── SirimScannerApplication.kt
+ │   └── res                     # Compose theme values and adaptive launcher icons
+ └── proguard-rules.pro
+```
+
+The remainder of this document retains the original MVP specification for reference.
+
+## Core Requirements
+### Basic Functionality
+- QR code / label scanning with advanced OCR.
+- Automatic data recognition that fills structured tables.
+- Fully offline operation with local data storage.
+- Export of captured data to PDF, Excel, and CSV.
+- Simple hardcoded authentication (admin / admin).
+- Prepared infrastructure for future online sync.
+
+### Data Structure
+The application captures the following fields per record:
+
+| Field | Max Length | Description |
+| --- | --- | --- |
+| SIRIM Serial No. | 12 | No spaces or dashes |
+| Batch No. | 200 | Product batch number |
+| Brand / Trademark | 1024 | As per license |
+| Model | 1500 | As per license |
+| Type | 1500 | As per license |
+| Rating | 600 | As per license |
+| Size | 1500 | Product size |
+
+## Technical Stack
+- **Language:** Kotlin
+- **Architecture:** MVVM + Clean Architecture
+- **UI:** Jetpack Compose
+- **Database:** Room
+- **Camera:** CameraX
+- **OCR:** Google ML Kit Vision (primary), Tesseract (fallback)
+- **Image Processing:** OpenCV
+- **QR Codes:** ZXing + ML Kit Barcode Scanner
+- **Exports:** iText 7 (PDF), Apache POI (Excel), built-in CSV handling
+- **Sharing:** Android ShareSheet API
+
+## Application Architecture
+```
+Login Screen (admin/admin)
+    ↓
+Main Dashboard
+    ↓
+Camera Scanner ← → Data Table View
+    ↓              ↓
+Data Entry     Export Options
+```
+
+### Key Screens
+- **LoginActivity:** Hardcoded authentication.
+- **MainActivity:** Dashboard with scanning entry points and record overview.
+- **ScannerActivity:** Camera with real-time OCR pipeline and manual capture.
+- **DataEntryActivity:** Manual data entry/editing.
+- **ExportActivity:** Export selection and format handling.
+
+## Database Schema (Room)
+```kotlin
+@Entity(
+    tableName = "sirim_records",
+    indices = [
+        Index(value = ["sirim_serial_no"], unique = true),
+        Index(value = ["created_at"]),
+        Index(value = ["brand_trademark"]),
+        Index(value = ["is_verified"])
+    ]
+)
+data class SirimRecord(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "sirim_serial_no")
+    val sirimSerialNo: String,
+    @ColumnInfo(name = "batch_no")
+    val batchNo: String,
+    @ColumnInfo(name = "brand_trademark")
+    val brandTrademark: String,
+    @ColumnInfo(name = "model")
+    val model: String,
+    @ColumnInfo(name = "type")
+    val type: String,
+    @ColumnInfo(name = "rating")
+    val rating: String,
+    @ColumnInfo(name = "size")
+    val size: String,
+    @ColumnInfo(name = "image_path")
+    val imagePath: String?,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+    @ColumnInfo(name = "is_verified")
+    val isVerified: Boolean = false,
+    @ColumnInfo(name = "needs_sync")
+    val needsSync: Boolean = true,
+    @ColumnInfo(name = "server_id")
+    val serverId: String? = null,
+    @ColumnInfo(name = "last_synced")
+    val lastSynced: Long? = null
+)
+```
+
+## Key Feature Implementation Notes
+### Enhanced Camera & OCR
+- Auto-adjust lighting, focus, and exposure using CameraX.
+- Real-time analysis using ML Kit with an automatic Tesseract fallback (requires the `eng.traineddata` model described above).
+- Image preprocessing via OpenCV for denoising, thresholding, and perspective cleanup.
+- Manual tap-to-capture option when auto detection is insufficient.
+
+### Batch Scanning
+- Toggle batch mode inside the scanner to queue multiple captures without leaving the camera view.
+- Review queued serials with per-item confidence summaries before committing.
+- Save or clear the queue in bulk; duplicates are automatically skipped during batch persistence.
+
+### Smart Data Extraction
+- Pattern recognition for SIRIM labels.
+- Automatic field mapping with validation.
+- Manual overrides for user corrections.
+
+### Data Management
+- Compose-based table view with free-text search, brand/date/verification filters, edit, and delete capabilities.
+- Stored images linked to records for reference.
+
+### Export Functionality
+- Export filtered record sets (brand, verification state, date range) to PDF, Excel, and CSV.
+- Excel exports include multi-sheet output (summary, full data, grouped by brand).
+- Generated files are stored under `Android/data/.../SIRIM_Exports/<yyyyMMdd>/` with timestamped filenames and can be shared via the ShareSheet.
+
+## Development Phases
+1. **Week 1 – Core Setup:** Project scaffolding, basic UI, Room integration, navigation.
+2. **Weeks 2-3 – Camera & OCR:** CameraX, ML Kit, Tesseract, OpenCV preprocessing, data extraction pipeline.
+3. **Week 4 – Data Management:** CRUD flows, validation, table/list presentation.
+4. **Weeks 5-6 – Export & Polish:** Export formats, sharing, UI polish, device testing.
+
+## Performance & Testing
+- Optimize camera frame processing, focus, and memory management.
+- Improve OCR accuracy with preprocessing and dual-engine validation.
+- Add Room indexing and pagination for large datasets.
+- Testing strategy covering unit, UI, camera/OCR, export, and multi-device scenarios.
+
+## Future Online Integration Prep
+- Implement repository pattern with Retrofit-ready data layer.
+- Track sync state (`needsSync`, `serverId`, `lastSynced`) for future server interactions.
+
+## Success Criteria
+- Accurate OCR (>90% for clear labels) within 3 seconds.
+- Seamless offline operation and storage efficiency (<10MB per 100 records with images).
+- Fast startup (<2 seconds) and exports (<5 seconds for 100 records).
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,100 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
+}
+
+android {
+    namespace = "com.sirim.scanner"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.sirim.scanner"
+        minSdk = 33
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.11"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.04.01")
+
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
+    implementation("androidx.camera:camera-core:1.3.2")
+    implementation("androidx.camera:camera-camera2:1.3.2")
+    implementation("androidx.camera:camera-lifecycle:1.3.2")
+    implementation("androidx.camera:camera-view:1.3.2")
+
+    implementation("com.google.mlkit:text-recognition:16.0.0")
+    implementation("com.google.mlkit:barcode-scanning:17.2.0")
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
+
+    implementation("org.opencv:opencv:4.9.0")
+    implementation("com.googlecode.tesseract.android:tess-two:9.1.0")
+
+    implementation("com.itextpdf:itext7-core:8.0.1")
+    implementation("org.apache.poi:poi-ooxml:5.2.5")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,11 @@
+# Keep ML Kit models and CameraX metadata
+-keep class com.google.mlkit.** { *; }
+-keep class androidx.camera.** { *; }
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**
+-keep class org.opencv.** { *; }
+-dontwarn org.apache.poi.**
+-dontwarn org.apache.xmlbeans.**
+-keep class com.itextpdf.** { *; }
+-keep class com.googlecode.tesseract.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:targetApi="q" />
+
+    <application
+        android:name=".SirimScannerApplication"
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.SirimScanner">
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
+        <activity
+            android:name="com.sirim.scanner.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/sirim/scanner/MainActivity.kt
+++ b/app/src/main/java/com/sirim/scanner/MainActivity.kt
@@ -1,0 +1,155 @@
+package com.sirim.scanner
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navArgument
+import androidx.navigation.compose.rememberNavController
+import com.sirim.scanner.data.AppContainer
+import com.sirim.scanner.ui.screens.dashboard.DashboardScreen
+import com.sirim.scanner.ui.screens.dashboard.DashboardViewModel
+import com.sirim.scanner.ui.screens.export.ExportScreen
+import com.sirim.scanner.ui.screens.export.ExportViewModel
+import com.sirim.scanner.ui.screens.login.LoginScreen
+import com.sirim.scanner.ui.screens.login.LoginViewModel
+import com.sirim.scanner.ui.screens.records.RecordFormScreen
+import com.sirim.scanner.ui.screens.records.RecordListScreen
+import com.sirim.scanner.ui.screens.records.RecordViewModel
+import com.sirim.scanner.ui.screens.scanner.ScannerScreen
+import com.sirim.scanner.ui.screens.scanner.ScannerViewModel
+import com.sirim.scanner.ui.theme.SirimScannerTheme
+
+class MainActivity : ComponentActivity() {
+
+    private val container: AppContainer by lazy {
+        (application as SirimScannerApplication).container
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            SirimScannerTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    SirimApp(container = container)
+                }
+            }
+        }
+    }
+}
+
+sealed class Destinations(val route: String) {
+    data object Login : Destinations("login")
+    data object Dashboard : Destinations("dashboard")
+    data object Scanner : Destinations("scanner")
+    data object RecordList : Destinations("records")
+    data object RecordForm : Destinations("recordForm")
+    data object Export : Destinations("export")
+}
+
+@Composable
+fun SirimApp(container: AppContainer) {
+    val navController = rememberNavController()
+    NavGraph(container = container, navController = navController)
+}
+
+@Composable
+private fun NavGraph(container: AppContainer, navController: NavHostController) {
+    NavHost(navController = navController, startDestination = Destinations.Login.route) {
+        composable(Destinations.Login.route) {
+            val viewModel: LoginViewModel = viewModel(factory = LoginViewModel.Factory())
+            LoginScreen(
+                viewModel = viewModel,
+                onAuthenticated = {
+                    navController.navigate(Destinations.Dashboard.route) {
+                        popUpTo(Destinations.Login.route) { inclusive = true }
+                    }
+                }
+            )
+        }
+        composable(Destinations.Dashboard.route) {
+            val viewModel: DashboardViewModel = viewModel(
+                factory = DashboardViewModel.Factory(container.repository)
+            )
+            DashboardScreen(
+                viewModel = viewModel,
+                navigateToScanner = { navController.navigate(Destinations.Scanner.route) },
+                navigateToRecords = { navController.navigate(Destinations.RecordList.route) },
+                navigateToExport = { navController.navigate(Destinations.Export.route) }
+            )
+        }
+        composable(Destinations.Scanner.route) {
+            val viewModel: ScannerViewModel = viewModel(
+                factory = ScannerViewModel.Factory(
+                    repository = container.repository,
+                    analyzer = container.labelAnalyzer,
+                    appScope = container.applicationScope
+                )
+            )
+            ScannerScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+                onRecordSaved = { id ->
+                    navController.navigate("${Destinations.RecordForm.route}?recordId=$id") {
+                        popUpTo(Destinations.Scanner.route) { inclusive = true }
+                    }
+                }
+            )
+        }
+        composable(Destinations.RecordList.route) {
+            val viewModel: RecordViewModel = viewModel(
+                factory = RecordViewModel.Factory(container.repository)
+            )
+            RecordListScreen(
+                viewModel = viewModel,
+                onAdd = { navController.navigate("${Destinations.RecordForm.route}") },
+                onEdit = { record ->
+                    navController.navigate("${Destinations.RecordForm.route}?recordId=${record.id}")
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+        composable(
+            route = Destinations.RecordForm.route + "?recordId={recordId}",
+            arguments = listOf(
+                navArgument("recordId") {
+                    type = NavType.LongType
+                    defaultValue = -1L
+                }
+            )
+        ) { backStackEntry ->
+            val viewModel: RecordViewModel = viewModel(
+                factory = RecordViewModel.Factory(container.repository)
+            )
+            RecordFormScreen(
+                viewModel = viewModel,
+                onSaved = {
+                    navController.popBackStack()
+                },
+                onBack = { navController.popBackStack() },
+                recordId = backStackEntry.arguments?.getLong("recordId")?.takeIf { it > 0 }
+            )
+        }
+        composable(Destinations.Export.route) {
+            val viewModel: ExportViewModel = viewModel(
+                factory = ExportViewModel.Factory(container.repository, container.exportManager)
+            )
+            ExportScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/SirimScannerApplication.kt
+++ b/app/src/main/java/com/sirim/scanner/SirimScannerApplication.kt
@@ -1,0 +1,15 @@
+package com.sirim.scanner
+
+import android.app.Application
+import com.sirim.scanner.data.AppContainer
+import com.sirim.scanner.data.DefaultAppContainer
+
+class SirimScannerApplication : Application() {
+    lateinit var container: AppContainer
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        container = DefaultAppContainer(this)
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/data/AppContainer.kt
+++ b/app/src/main/java/com/sirim/scanner/data/AppContainer.kt
@@ -1,0 +1,50 @@
+package com.sirim.scanner.data
+
+import android.content.Context
+import androidx.room.Room
+import com.sirim.scanner.data.db.SirimDatabase
+import com.sirim.scanner.data.export.ExportManager
+import com.sirim.scanner.data.ocr.LabelAnalyzer
+import com.sirim.scanner.data.ocr.TesseractManager
+import com.sirim.scanner.data.repository.SirimRepository
+import com.sirim.scanner.data.repository.SirimRepositoryImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+interface AppContainer {
+    val repository: SirimRepository
+    val exportManager: ExportManager
+    val labelAnalyzer: LabelAnalyzer
+    val applicationScope: CoroutineScope
+}
+
+class DefaultAppContainer(private val context: Context) : AppContainer {
+    private val applicationScopeImpl = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val database: SirimDatabase = Room.databaseBuilder(
+        context,
+        SirimDatabase::class.java,
+        "sirim_records.db"
+    ).fallbackToDestructiveMigration().build()
+
+    override val repository: SirimRepository by lazy {
+        SirimRepositoryImpl(
+            dao = database.sirimRecordDao(),
+            context = context.applicationContext
+        )
+    }
+
+    override val exportManager: ExportManager by lazy {
+        ExportManager(context.applicationContext)
+    }
+
+    private val tesseractManager: TesseractManager by lazy {
+        TesseractManager(context.applicationContext)
+    }
+
+    override val labelAnalyzer: LabelAnalyzer by lazy { LabelAnalyzer(tesseractManager) }
+
+    override val applicationScope: CoroutineScope
+        get() = applicationScopeImpl
+}

--- a/app/src/main/java/com/sirim/scanner/data/db/SirimDatabase.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/SirimDatabase.kt
@@ -1,0 +1,13 @@
+package com.sirim.scanner.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [SirimRecord::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class SirimDatabase : RoomDatabase() {
+    abstract fun sirimRecordDao(): SirimRecordDao
+}

--- a/app/src/main/java/com/sirim/scanner/data/db/SirimRecord.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/SirimRecord.kt
@@ -1,0 +1,46 @@
+package com.sirim.scanner.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "sirim_records",
+    indices = [
+        Index(value = ["sirim_serial_no"], unique = true),
+        Index(value = ["created_at"]),
+        Index(value = ["brand_trademark"]),
+        Index(value = ["is_verified"])
+    ]
+)
+data class SirimRecord(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "sirim_serial_no")
+    val sirimSerialNo: String,
+    @ColumnInfo(name = "batch_no")
+    val batchNo: String,
+    @ColumnInfo(name = "brand_trademark")
+    val brandTrademark: String,
+    @ColumnInfo(name = "model")
+    val model: String,
+    @ColumnInfo(name = "type")
+    val type: String,
+    @ColumnInfo(name = "rating")
+    val rating: String,
+    @ColumnInfo(name = "size")
+    val size: String,
+    @ColumnInfo(name = "image_path")
+    val imagePath: String?,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+    @ColumnInfo(name = "is_verified")
+    val isVerified: Boolean = false,
+    @ColumnInfo(name = "needs_sync")
+    val needsSync: Boolean = true,
+    @ColumnInfo(name = "server_id")
+    val serverId: String? = null,
+    @ColumnInfo(name = "last_synced")
+    val lastSynced: Long? = null
+)

--- a/app/src/main/java/com/sirim/scanner/data/db/SirimRecordDao.kt
+++ b/app/src/main/java/com/sirim/scanner/data/db/SirimRecordDao.kt
@@ -1,0 +1,38 @@
+package com.sirim.scanner.data.db
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SirimRecordDao {
+    @Query("SELECT * FROM sirim_records ORDER BY created_at DESC")
+    fun getAllRecords(): Flow<List<SirimRecord>>
+
+    @Query("SELECT * FROM sirim_records WHERE id = :id")
+    suspend fun getRecordById(id: Long): SirimRecord?
+
+    @Query("SELECT * FROM sirim_records WHERE sirim_serial_no = :serial LIMIT 1")
+    suspend fun findBySerial(serial: String): SirimRecord?
+
+    @Query(
+        "SELECT * FROM sirim_records WHERE sirim_serial_no LIKE :query OR batch_no LIKE :query OR brand_trademark LIKE :query OR model LIKE :query ORDER BY created_at DESC"
+    )
+    fun searchRecords(query: String): Flow<List<SirimRecord>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(record: SirimRecord): Long
+
+    @Update
+    suspend fun update(record: SirimRecord)
+
+    @Delete
+    suspend fun delete(record: SirimRecord)
+
+    @Query("DELETE FROM sirim_records")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/sirim/scanner/data/export/ExportFormat.kt
+++ b/app/src/main/java/com/sirim/scanner/data/export/ExportFormat.kt
@@ -1,0 +1,7 @@
+package com.sirim.scanner.data.export
+
+enum class ExportFormat {
+    Pdf,
+    Excel,
+    Csv
+}

--- a/app/src/main/java/com/sirim/scanner/data/export/ExportManager.kt
+++ b/app/src/main/java/com/sirim/scanner/data/export/ExportManager.kt
@@ -1,0 +1,222 @@
+package com.sirim.scanner.data.export
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.itextpdf.kernel.pdf.PdfWriter
+import com.itextpdf.layout.Document
+import com.itextpdf.layout.element.Cell
+import com.itextpdf.layout.element.Paragraph
+import com.itextpdf.layout.element.Table
+import com.sirim.scanner.data.export.ExportFormat
+import com.sirim.scanner.data.db.SirimRecord
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import org.apache.poi.ss.usermodel.BorderStyle
+import org.apache.poi.ss.usermodel.HorizontalAlignment
+import org.apache.poi.ss.util.CellRangeAddress
+import org.apache.poi.xssf.usermodel.XSSFCellStyle
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+
+class ExportManager(private val context: Context) {
+
+    private val headers = listOf(
+        "SIRIM Serial No.",
+        "Batch No.",
+        "Brand/Trademark",
+        "Model",
+        "Type",
+        "Rating",
+        "Size"
+    )
+
+    fun exportToPdf(records: List<SirimRecord>): Uri {
+        val file = createExportFile("pdf")
+        PdfWriter(FileOutputStream(file)).use { writer ->
+            val document = Document(com.itextpdf.kernel.pdf.PdfDocument(writer))
+            document.add(Paragraph("SIRIM Records"))
+            val table = Table(headers.size.toFloat())
+            headers.forEach { header ->
+                table.addHeaderCell(Cell().add(Paragraph(header)))
+            }
+            records.forEach { record ->
+                record.toFieldList().forEach { value ->
+                    table.addCell(Cell().add(Paragraph(value)))
+                }
+            }
+            document.add(table)
+            document.close()
+        }
+        return toFileUri(file)
+    }
+
+    fun exportToCsv(records: List<SirimRecord>): Uri {
+        val file = createExportFile("csv")
+        FileOutputStream(file).use { output ->
+            OutputStreamWriter(output).use { writer ->
+                writer.appendLine(headers.joinToString(","))
+                records.forEach { record ->
+                    writer.appendLine(record.toFieldList().joinToString(","))
+                }
+            }
+        }
+        return toFileUri(file)
+    }
+
+    fun exportToExcel(records: List<SirimRecord>): Uri {
+        val file = createExportFile("xlsx")
+        XSSFWorkbook().use { workbook ->
+            createSummarySheet(workbook.createSheet("Summary"), records)
+            createDataSheet(workbook.createSheet("All Records"), records)
+            createBrandSheet(workbook.createSheet("By Brand"), records)
+
+            FileOutputStream(file).use { output ->
+                workbook.write(output)
+            }
+        }
+        return toFileUri(file)
+    }
+
+    fun exportByDateRange(
+        records: List<SirimRecord>,
+        startDate: Long?,
+        endDate: Long?,
+        format: ExportFormat
+    ): Uri {
+        val filtered = records.filter { record ->
+            val createdAt = record.createdAt
+            val afterStart = startDate?.let { createdAt >= it } ?: true
+            val beforeEnd = endDate?.let { createdAt <= it } ?: true
+            afterStart && beforeEnd
+        }
+        return when (format) {
+            ExportFormat.Pdf -> exportToPdf(filtered)
+            ExportFormat.Excel -> exportToExcel(filtered)
+            ExportFormat.Csv -> exportToCsv(filtered)
+        }
+    }
+
+    private fun createSummarySheet(sheet: org.apache.poi.ss.usermodel.Sheet, records: List<SirimRecord>) {
+        var rowIndex = 0
+        val headerRow = sheet.createRow(rowIndex++)
+        headerRow.createCell(0).setCellValue("SIRIM Record Summary")
+
+        val totalsRow = sheet.createRow(rowIndex++)
+        totalsRow.createCell(0).setCellValue("Total Records")
+        totalsRow.createCell(1).setCellValue(records.size.toDouble())
+
+        val verifiedCount = records.count { it.isVerified }
+        val verifiedRow = sheet.createRow(rowIndex++)
+        verifiedRow.createCell(0).setCellValue("Verified")
+        verifiedRow.createCell(1).setCellValue(verifiedCount.toDouble())
+
+        val pendingRow = sheet.createRow(rowIndex++)
+        pendingRow.createCell(0).setCellValue("Pending Verification")
+        pendingRow.createCell(1).setCellValue((records.size - verifiedCount).toDouble())
+
+        if (records.isNotEmpty()) {
+            rowIndex++
+            val topBrandsRow = sheet.createRow(rowIndex++)
+            topBrandsRow.createCell(0).setCellValue("Top Brands")
+
+            records.groupBy { it.brandTrademark }
+                .mapValues { (_, values) -> values.size }
+                .entries
+                .sortedByDescending { it.value }
+                .take(5)
+                .forEach { (brand, count) ->
+                    val row = sheet.createRow(rowIndex++)
+                    row.createCell(0).setCellValue(brand)
+                    row.createCell(1).setCellValue(count.toDouble())
+                }
+        }
+    }
+
+    private fun createDataSheet(sheet: org.apache.poi.ss.usermodel.Sheet, records: List<SirimRecord>) {
+        val headerStyle: XSSFCellStyle = (sheet.workbook as XSSFWorkbook).createCellStyle().apply {
+            alignment = HorizontalAlignment.CENTER
+            borderBottom = BorderStyle.MEDIUM
+        }
+        val headerRow = sheet.createRow(0)
+        headers.forEachIndexed { index, header ->
+            sheet.setColumnWidth(index, 20_000)
+            val cell = headerRow.createCell(index)
+            cell.setCellValue(header)
+            cell.cellStyle = headerStyle
+        }
+        records.forEachIndexed { rowIndex, record ->
+            val row = sheet.createRow(rowIndex + 1)
+            record.toFieldList().forEachIndexed { columnIndex, value ->
+                row.createCell(columnIndex).setCellValue(value)
+            }
+        }
+        sheet.setAutoFilter(CellRangeAddress(0, records.size, 0, headers.lastIndex))
+    }
+
+    private fun createBrandSheet(sheet: org.apache.poi.ss.usermodel.Sheet, records: List<SirimRecord>) {
+        val workbook = sheet.workbook as XSSFWorkbook
+        val headerStyle = workbook.createCellStyle().apply {
+            alignment = HorizontalAlignment.CENTER
+            borderBottom = BorderStyle.MEDIUM
+        }
+        val headerRow = sheet.createRow(0)
+        listOf("Brand", "Records", "Verified").forEachIndexed { index, title ->
+            sheet.setColumnWidth(index, 10_000)
+            val cell = headerRow.createCell(index)
+            cell.setCellValue(title)
+            cell.cellStyle = headerStyle
+        }
+
+        records.groupBy { it.brandTrademark }
+            .entries
+            .sortedByDescending { it.value.size }
+            .forEachIndexed { index, entry ->
+                val row = sheet.createRow(index + 1)
+                row.createCell(0).setCellValue(entry.key)
+                row.createCell(1).setCellValue(entry.value.size.toDouble())
+                row.createCell(2).setCellValue(entry.value.count { it.isVerified }.toDouble())
+            }
+    }
+
+    private fun createExportFile(extension: String, prefix: String = "sirim_records"): File {
+        val directory = getExportDirectory()
+        val timestamp = formatTimestamp(FILE_NAME_FORMAT)
+        return File(directory, "${prefix}_$timestamp.$extension")
+    }
+
+    private fun getExportDirectory(): File {
+        val directoryName = formatTimestamp(DIRECTORY_FORMAT)
+        val exportDir = File(context.getExternalFilesDir(null), "SIRIM_Exports/$directoryName")
+        if (!exportDir.exists()) {
+            exportDir.mkdirs()
+        }
+        return exportDir
+    }
+
+    private fun toFileUri(file: File): Uri = FileProvider.getUriForFile(
+        context,
+        context.packageName + ".provider",
+        file
+    )
+
+    private fun SirimRecord.toFieldList(): List<String> = listOf(
+        sirimSerialNo,
+        batchNo,
+        brandTrademark,
+        model,
+        type,
+        rating,
+        size
+    )
+}
+
+private val FILE_NAME_FORMAT = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault())
+private val DIRECTORY_FORMAT = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
+
+private fun formatTimestamp(format: SimpleDateFormat): String = synchronized(format) {
+    format.format(Date())
+}

--- a/app/src/main/java/com/sirim/scanner/data/ocr/BitmapUtils.kt
+++ b/app/src/main/java/com/sirim/scanner/data/ocr/BitmapUtils.kt
@@ -1,0 +1,31 @@
+package com.sirim.scanner.data.ocr
+
+import android.graphics.Bitmap
+import android.graphics.ImageFormat
+import android.graphics.YuvImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+object BitmapUtils {
+    fun nv21ToBitmap(nv21: ByteArray, width: Int, height: Int): Bitmap? {
+        val yuvImage = YuvImage(nv21, ImageFormat.NV21, width, height, null)
+        val outputStream = ByteArrayOutputStream()
+        if (!yuvImage.compressToJpeg(android.graphics.Rect(0, 0, width, height), 90, outputStream)) {
+            return null
+        }
+        val jpegBytes = outputStream.toByteArray()
+        return android.graphics.BitmapFactory.decodeByteArray(jpegBytes, 0, jpegBytes.size)
+    }
+}
+
+fun Bitmap.toInputStream(): ByteArrayInputStream {
+    val outputStream = ByteArrayOutputStream()
+    compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
+    return ByteArrayInputStream(outputStream.toByteArray())
+}
+
+fun Bitmap.toJpegByteArray(quality: Int = 90): ByteArray {
+    val outputStream = ByteArrayOutputStream()
+    compress(Bitmap.CompressFormat.JPEG, quality, outputStream)
+    return outputStream.toByteArray()
+}

--- a/app/src/main/java/com/sirim/scanner/data/ocr/FieldConfidence.kt
+++ b/app/src/main/java/com/sirim/scanner/data/ocr/FieldConfidence.kt
@@ -1,0 +1,34 @@
+package com.sirim.scanner.data.ocr
+
+import kotlin.math.max
+
+/**
+ * Represents a field extracted from the OCR/QR pipeline with a confidence score and source.
+ */
+data class FieldConfidence(
+    val value: String,
+    val confidence: Float,
+    val source: FieldSource,
+    val notes: Set<FieldNote> = emptySet()
+) {
+    fun mergeWith(other: FieldConfidence): FieldConfidence {
+        val dominant = if (confidence >= other.confidence) this else other
+        val combinedConfidence = max(confidence, other.confidence)
+        val combinedNotes = notes + other.notes + if (value != other.value) setOf(FieldNote.CONFLICT) else emptySet()
+        return dominant.copy(confidence = combinedConfidence, notes = combinedNotes)
+    }
+}
+
+enum class FieldSource {
+    OCR,
+    QR,
+    USER
+}
+
+enum class FieldNote {
+    CORRECTED_CHARACTER,
+    PATTERN_RELAXED,
+    LENGTH_TRIMMED,
+    FORMAT_MISMATCH,
+    CONFLICT
+}

--- a/app/src/main/java/com/sirim/scanner/data/ocr/ImagePreprocessor.kt
+++ b/app/src/main/java/com/sirim/scanner/data/ocr/ImagePreprocessor.kt
@@ -1,0 +1,151 @@
+package com.sirim.scanner.data.ocr
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import androidx.camera.core.ImageProxy
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.abs
+import org.opencv.android.OpenCVLoader
+import org.opencv.android.Utils
+import org.opencv.core.Core
+import org.opencv.core.CvType
+import org.opencv.core.Mat
+import org.opencv.core.MatOfPoint
+import org.opencv.core.MatOfPoint2f
+import org.opencv.core.Rect as CvRect
+import org.opencv.core.Size
+import org.opencv.imgproc.Imgproc
+
+data class PreprocessedImage(
+    val original: Bitmap,
+    val enhanced: Bitmap,
+    val regionOfInterest: Rect?
+)
+
+object ImagePreprocessor {
+
+    private val opencvInitialised = AtomicBoolean(false)
+
+    fun preprocess(imageProxy: ImageProxy): PreprocessedImage? {
+        val original = imageProxy.toBitmap() ?: return null
+        ensureOpenCv()
+
+        val mats = mutableListOf<Mat>()
+        val rgba = Mat()
+        Utils.bitmapToMat(original, rgba)
+        mats += rgba
+        Imgproc.cvtColor(rgba, rgba, Imgproc.COLOR_RGBA2RGB)
+
+        val gray = Mat()
+        mats += gray
+        Imgproc.cvtColor(rgba, gray, Imgproc.COLOR_RGB2GRAY)
+
+        val clahe = Imgproc.createCLAHE(2.0, Size(8.0, 8.0))
+        val equalized = Mat()
+        mats += equalized
+        clahe.apply(gray, equalized)
+        clahe.close()
+
+        val denoised = Mat()
+        mats += denoised
+        Imgproc.bilateralFilter(equalized, denoised, 5, 75.0, 75.0)
+
+        val sharpenKernel = Mat(3, 3, CvType.CV_32F)
+        mats += sharpenKernel
+        sharpenKernel.put(0, 0,
+            0.0, -1.0, 0.0,
+            -1.0, 5.0, -1.0,
+            0.0, -1.0, 0.0
+        )
+        val sharpened = Mat()
+        mats += sharpened
+        Imgproc.filter2D(denoised, sharpened, -1, sharpenKernel)
+
+        val thresholded = Mat()
+        mats += thresholded
+        Imgproc.adaptiveThreshold(
+            sharpened,
+            thresholded,
+            255.0,
+            Imgproc.ADAPTIVE_THRESH_GAUSSIAN_C,
+            Imgproc.THRESH_BINARY,
+            31,
+            10.0
+        )
+
+        val deskewed = deskew(thresholded)
+        if (deskewed !== thresholded) {
+            mats += deskewed
+        }
+        val roi = detectRoi(deskewed)
+        val finalMat = if (roi != null) Mat(deskewed, roi) else deskewed
+        if (finalMat !== deskewed) {
+            mats += finalMat
+        }
+
+        val rgbaFinal = Mat()
+        mats += rgbaFinal
+        Imgproc.cvtColor(finalMat, rgbaFinal, Imgproc.COLOR_GRAY2RGBA)
+        val enhanced = Bitmap.createBitmap(rgbaFinal.cols(), rgbaFinal.rows(), Bitmap.Config.ARGB_8888)
+        Utils.matToBitmap(rgbaFinal, enhanced)
+
+        val region = roi?.let { Rect(it.x, it.y, it.width, it.height) }
+
+        mats.forEach(Mat::release)
+
+        return PreprocessedImage(
+            original = original,
+            enhanced = enhanced,
+            regionOfInterest = region
+        )
+    }
+
+    private fun ensureOpenCv() {
+        if (opencvInitialised.get()) return
+        opencvInitialised.compareAndSet(false, OpenCVLoader.initLocal())
+    }
+
+    private fun deskew(source: Mat): Mat {
+        val nonZero = Mat()
+        Core.findNonZero(source, nonZero)
+        if (nonZero.empty()) {
+            nonZero.release()
+            return source
+        }
+        val points = MatOfPoint2f()
+        nonZero.convertTo(points, CvType.CV_32F)
+        nonZero.release()
+        val box = Imgproc.minAreaRect(points)
+        points.release()
+        var angle = box.angle
+        if (angle < -45) angle += 90.0
+        if (abs(angle) < 0.5) {
+            return source
+        }
+        val rotationMatrix = Imgproc.getRotationMatrix2D(box.center, angle, 1.0)
+        val rotated = Mat()
+        Imgproc.warpAffine(source, rotated, rotationMatrix, source.size(), Imgproc.INTER_LINEAR)
+        rotationMatrix.release()
+        return rotated
+    }
+
+    private fun detectRoi(source: Mat): CvRect? {
+        val contours = mutableListOf<MatOfPoint>()
+        val hierarchy = Mat()
+        val working = source.clone()
+        Imgproc.GaussianBlur(working, working, Size(5.0, 5.0), 0.0)
+        Imgproc.Canny(working, working, 50.0, 150.0)
+        Imgproc.findContours(working, contours, hierarchy, Imgproc.RETR_EXTERNAL, Imgproc.CHAIN_APPROX_SIMPLE)
+        hierarchy.release()
+        working.release()
+        val largest = contours.maxByOrNull { contour -> Imgproc.contourArea(contour) }
+        contours.filter { it !== largest }.forEach(Mat::release)
+        if (largest == null) {
+            return null
+        }
+        val rect = Imgproc.boundingRect(largest)
+        largest.release()
+        val minArea = source.width() * source.height() * 0.1
+        return if (rect.width * rect.height < minArea) null else rect
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/data/ocr/LabelAnalyzer.kt
+++ b/app/src/main/java/com/sirim/scanner/data/ocr/LabelAnalyzer.kt
@@ -1,0 +1,259 @@
+package com.sirim.scanner.data.ocr
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import androidx.camera.core.ImageProxy
+import com.google.mlkit.vision.barcode.Barcode
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.Result
+import com.google.zxing.common.HybridBinarizer
+import com.google.zxing.RGBLuminanceSource
+import java.nio.ByteBuffer
+import java.util.ArrayDeque
+import kotlin.math.max
+import kotlin.math.min
+import kotlinx.coroutines.tasks.await
+
+class LabelAnalyzer(
+    private val tesseractManager: TesseractManager,
+    private val frameWindow: Int = 8,
+    private val successThreshold: Float = 0.75f
+) {
+
+    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    private val barcodeScanner = BarcodeScanning.getClient(
+        BarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .build()
+    )
+    private val multiFormatReader = MultiFormatReader()
+    private val recentFrames = ArrayDeque<FrameObservation>()
+
+    suspend fun analyze(imageProxy: ImageProxy): OcrResult {
+        val preprocessed = ImagePreprocessor.preprocess(imageProxy) ?: return OcrResult.Empty
+
+        val textSegments = mutableListOf<String>()
+        recognizeText(preprocessed.enhanced)?.let(textSegments::add)
+
+        val rotatedVariants = listOf(90f, -90f)
+        rotatedVariants.forEach { angle ->
+            var rotated: Bitmap? = null
+            try {
+                rotated = preprocessed.enhanced.rotate(angle)
+                if (rotated != null) {
+                    recognizeText(rotated)?.let(textSegments::add)
+                }
+            } finally {
+                if (rotated != null && rotated !== preprocessed.enhanced && !rotated.isRecycled) {
+                    rotated.recycle()
+                }
+            }
+        }
+
+        val combinedText = textSegments.joinToString("\n") { it.trim() }
+        val parsedFields = if (combinedText.isNotBlank()) {
+            SirimLabelParser.parse(combinedText).toMutableMap()
+        } else {
+            mutableMapOf()
+        }
+
+        val barcodeImage = InputImage.fromBitmap(preprocessed.original, 0)
+        val barcodeResults = barcodeScanner.safeProcess(barcodeImage)
+        val qrPayload = barcodeResults.firstOrNull()?.rawValue
+            ?: decodeWithZxing(preprocessed.original)
+            ?: preprocessed.regionOfInterest?.let { region ->
+                preprocessed.original.safeCrop(region)?.use { cropped ->
+                    decodeWithZxing(cropped)
+                }
+            }
+
+        val qrField = SirimLabelParser.mergeWithQr(parsedFields, qrPayload)
+        val observation = FrameObservation(
+            fields = parsedFields,
+            qr = qrField,
+            confidence = parsedFields.averageConfidence()
+        )
+        val consensus = updateConsensus(observation)
+
+        val aggregatedFields = consensus?.fields ?: parsedFields
+        val aggregatedConfidence = consensus?.confidence ?: observation.confidence
+        val frames = consensus?.frames ?: 1
+        val isStable = consensus?.isStable ?: (aggregatedConfidence >= successThreshold && frames >= 2)
+
+        if (aggregatedFields.isEmpty()) {
+            return OcrResult.Empty
+        }
+
+        val qrValue = consensus?.qr?.value ?: qrField?.value ?: qrPayload
+        return if (isStable) {
+            OcrResult.Success(
+                fields = aggregatedFields,
+                qrCode = qrValue,
+                bitmap = preprocessed.original,
+                confidence = aggregatedConfidence,
+                frames = frames
+            )
+        } else {
+            OcrResult.Partial(
+                fields = aggregatedFields,
+                qrCode = qrValue,
+                bitmap = preprocessed.original,
+                confidence = aggregatedConfidence,
+                frames = frames
+            )
+        }
+    }
+
+    private fun updateConsensus(observation: FrameObservation): ConsensusResult? {
+        recentFrames.addLast(observation)
+        if (recentFrames.size > frameWindow) {
+            recentFrames.removeFirst()
+        }
+        val aggregated = mutableMapOf<String, FieldConfidence>()
+        val frequency = mutableMapOf<String, MutableMap<String, Int>>()
+
+        recentFrames.forEach { frame ->
+            frame.fields.forEach { (key, candidate) ->
+                val valueKey = candidate.value.uppercase()
+                val fieldFrequency = frequency.getOrPut(key) { mutableMapOf() }
+                val count = fieldFrequency.getOrPut(valueKey) { 0 } + 1
+                fieldFrequency[valueKey] = count
+                val boostedConfidence = (candidate.confidence + count * 0.08f).coerceAtMost(0.98f)
+                val adjusted = candidate.copy(confidence = boostedConfidence)
+                aggregated.merge(key, adjusted) { old, new ->
+                    when {
+                        old.value.equals(new.value, ignoreCase = true) ->
+                            old.copy(confidence = max(old.confidence, new.confidence), notes = old.notes + new.notes)
+                        new.confidence > old.confidence -> new.mergeWith(old)
+                        else -> old.mergeWith(new)
+                    }
+                }
+            }
+        }
+
+        val consensusConfidence = aggregated.values.map(FieldConfidence::confidence).average().toFloat()
+        val stableFields = aggregated.count { (key, candidate) ->
+            val fieldFreq = frequency[key]?.get(candidate.value.uppercase()) ?: 0
+            fieldFreq >= min(3, frameWindow / 2)
+        }
+        val isStable = stableFields >= 3 || (consensusConfidence >= successThreshold && stableFields >= 2)
+        val qrField = aggregated["sirimSerialNo"]
+        return ConsensusResult(
+            fields = aggregated,
+            confidence = consensusConfidence,
+            isStable = isStable,
+            frames = recentFrames.size,
+            qr = qrField
+        )
+    }
+
+    private fun Map<String, FieldConfidence>.averageConfidence(): Float =
+        if (isEmpty()) 0f else values.map(FieldConfidence::confidence).average().toFloat()
+
+    private suspend fun recognizeText(bitmap: Bitmap): String? {
+        val mlResult = runCatching {
+            recognizer.process(InputImage.fromBitmap(bitmap, 0)).await()
+        }.getOrNull()?.text?.takeIf { it.isNotBlank() }
+
+        if (!mlResult.isNullOrBlank()) {
+            return mlResult
+        }
+
+        var converted: Bitmap? = null
+        return try {
+            val source = if (bitmap.config == Bitmap.Config.ARGB_8888) {
+                bitmap
+            } else {
+                bitmap.copy(Bitmap.Config.ARGB_8888, false).also { converted = it }
+            }
+            tesseractManager.recognise(source)
+        } finally {
+            converted?.recycle()
+        }
+    }
+
+    private suspend fun com.google.mlkit.vision.barcode.BarcodeScanner.safeProcess(image: InputImage) =
+        runCatching { process(image).await() }.getOrNull().orEmpty()
+
+    private fun decodeWithZxing(bitmap: Bitmap): String? {
+        val width = bitmap.width
+        val height = bitmap.height
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+        val source = RGBLuminanceSource(width, height, pixels)
+        val binary = BinaryBitmap(HybridBinarizer(source))
+        return runCatching<Result> {
+            multiFormatReader.decode(binary)
+        }.onSuccess {
+            multiFormatReader.reset()
+        }.getOrNull()?.text
+    }
+}
+
+sealed interface OcrResult {
+    data class Success(
+        val fields: Map<String, FieldConfidence>,
+        val qrCode: String?,
+        val bitmap: Bitmap?,
+        val confidence: Float,
+        val frames: Int
+    ) : OcrResult
+
+    data class Partial(
+        val fields: Map<String, FieldConfidence>,
+        val qrCode: String?,
+        val bitmap: Bitmap?,
+        val confidence: Float,
+        val frames: Int
+    ) : OcrResult
+
+    data object Empty : OcrResult
+}
+
+private data class FrameObservation(
+    val fields: Map<String, FieldConfidence>,
+    val qr: FieldConfidence?,
+    val confidence: Float
+)
+
+private data class ConsensusResult(
+    val fields: Map<String, FieldConfidence>,
+    val confidence: Float,
+    val isStable: Boolean,
+    val frames: Int,
+    val qr: FieldConfidence?
+)
+
+private fun ImageProxy.toBitmap(): Bitmap? {
+    val buffer: ByteBuffer = planes.firstOrNull()?.buffer ?: return null
+    val bytes = ByteArray(buffer.remaining())
+    buffer.get(bytes)
+    return BitmapUtils.nv21ToBitmap(bytes, width, height)?.rotate(imageInfo.rotationDegrees.toFloat())
+}
+
+private fun Bitmap.rotate(degrees: Float): Bitmap? = if (degrees == 0f) this else {
+    val matrix = android.graphics.Matrix().apply { postRotate(degrees) }
+    Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
+}
+
+private inline fun <T> Bitmap.use(block: (Bitmap) -> T): T {
+    return try {
+        block(this)
+    } finally {
+        if (!isRecycled) recycle()
+    }
+}
+
+private fun Bitmap.safeCrop(rect: Rect): Bitmap? = runCatching {
+    val left = rect.left.coerceIn(0, width - 1)
+    val top = rect.top.coerceIn(0, height - 1)
+    val right = rect.right.coerceIn(left + 1, width)
+    val bottom = rect.bottom.coerceIn(top + 1, height)
+    Bitmap.createBitmap(this, left, top, right - left, bottom - top)
+}.getOrNull()

--- a/app/src/main/java/com/sirim/scanner/data/ocr/SirimLabelParser.kt
+++ b/app/src/main/java/com/sirim/scanner/data/ocr/SirimLabelParser.kt
@@ -1,0 +1,194 @@
+package com.sirim.scanner.data.ocr
+
+import java.util.Locale
+import kotlin.math.min
+
+object SirimLabelParser {
+
+    private val characterCorrections = mapOf(
+        'O' to '0',
+        'o' to '0',
+        'I' to '1',
+        'l' to '1',
+        'S' to '5',
+        's' to '5',
+        'B' to '8'
+    )
+
+    private val serialPatterns = listOf(
+        Regex("\\bTEA[-\\s]?([0-9O]{7})\\b", RegexOption.IGNORE_CASE),
+        Regex("\\bT[-\\s]?([0-9O]{9})\\b", RegexOption.IGNORE_CASE),
+        Regex("\\bSerial\\s*(No|Number)?[:\\uFF1A\\-]?\\s*([A-Z0-9]{6,12})\\b", RegexOption.IGNORE_CASE)
+    )
+
+    private val fieldPatterns = mapOf(
+        "batchNo" to listOf(
+            Regex("Batch\\s*(No|Number)?\\.?\\s*[:\\uFF1A\\-]?\\s*([A-Z0-9-]{5,200})", RegexOption.IGNORE_CASE),
+            Regex("\\b([A-Z]{2,}-\\d{4,})\\b")
+        ),
+        "brandTrademark" to listOf(
+            Regex("Brand\\s*/?\\s*Trademark\\s*[:\\uFF1A\\-]?\\s*([A-Z0-9 &'\\-]{2,1024})", RegexOption.IGNORE_CASE)
+        ),
+        "model" to listOf(
+            Regex("Model\\s*[:\\uFF1A\\-]?\\s*([A-Za-z0-9\\- /]{2,1500})", RegexOption.IGNORE_CASE)
+        ),
+        "type" to listOf(
+            Regex("Type\\s*[:\\uFF1A\\-]?\\s*([A-Za-z0-9\\- /]{2,1500})", RegexOption.IGNORE_CASE)
+        ),
+        "rating" to listOf(
+            Regex("Rating\\s*[:\\uFF1A\\-]?\\s*([A-Za-z0-9\\- /]{1,600})", RegexOption.IGNORE_CASE),
+            Regex("SAE\\s*([0-9]{1,2}W-?[0-9]{1,2})", RegexOption.IGNORE_CASE)
+        ),
+        "size" to listOf(
+            Regex("Size\\s*[:\\uFF1A\\-]?\\s*([0-9]+\\s*(L|ML|LITRE|LTR|KG))", RegexOption.IGNORE_CASE),
+            Regex("([0-9]+\\s*(L|ML|LITRE|LTR|KG))", RegexOption.IGNORE_CASE)
+        )
+    )
+
+    fun parse(text: String): Map<String, FieldConfidence> {
+        if (text.isBlank()) return emptyMap()
+
+        val normalized = collapseVerticalText(text)
+        val candidates = mutableMapOf<String, FieldConfidence>()
+
+        extractSerial(normalized)?.let { serial ->
+            candidates["sirimSerialNo"] = serial
+        }
+
+        fieldPatterns.forEach { (field, patterns) ->
+            patterns.forEachIndexed { index, pattern ->
+                val match = pattern.find(normalized)
+                if (match != null) {
+                    val raw = match.groupValues.last().trim()
+                    val candidate = buildCandidate(field, raw, primaryPattern = index == 0)
+                    candidates.merge(field, candidate) { old, new -> old.mergeWith(new) }
+                }
+            }
+        }
+
+        return candidates
+    }
+
+    fun mergeWithQr(
+        current: MutableMap<String, FieldConfidence>,
+        qrPayload: String?
+    ): FieldConfidence? {
+        val qrSerial = qrPayload?.let { payload ->
+            val match = Regex("T[0-9]{9}", RegexOption.IGNORE_CASE).find(payload)
+            match?.value?.uppercase(Locale.getDefault())
+        } ?: return null
+
+        val corrected = correctCharacters(qrSerial)
+        val qrConfidence = FieldConfidence(
+            value = corrected.first,
+            confidence = 0.95f,
+            source = FieldSource.QR,
+            notes = corrected.second
+        )
+
+        val existing = current["sirimSerialNo"]
+        if (existing != null) {
+            val merged = existing.mergeWith(qrConfidence)
+            current["sirimSerialNo"] = merged
+            return merged
+        }
+        current["sirimSerialNo"] = qrConfidence
+        return qrConfidence
+    }
+
+    fun prettifyKey(key: String): String = key.replace(Regex("([A-Z])")) {
+        " " + it.value.lowercase(Locale.getDefault())
+    }.trim().replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
+    private fun extractSerial(text: String): FieldConfidence? {
+        serialPatterns.forEachIndexed { index, regex ->
+            val match = regex.find(text)
+            if (match != null) {
+                val raw = match.groupValues.last().trim()
+                val (corrected, notes) = correctCharacters(raw)
+                val normalized = corrected.uppercase(Locale.getDefault())
+                val confidenceBoost = if (index == 0) 0.35f else 0.2f
+                val confidence = 0.55f + confidenceBoost - 0.05f * notes.count()
+                return FieldConfidence(
+                    value = normalized,
+                    confidence = confidence.coerceIn(0.1f, 0.95f),
+                    source = FieldSource.OCR,
+                    notes = notes
+                )
+            }
+        }
+        return null
+    }
+
+    private fun buildCandidate(
+        field: String,
+        rawValue: String,
+        primaryPattern: Boolean
+    ): FieldConfidence {
+        val (corrected, notes) = correctCharacters(rawValue)
+        val trimmed = enforceLength(field, corrected)
+        val baseConfidence = if (primaryPattern) 0.55f else 0.45f
+        val lengthPenalty = if (trimmed.second) 0.05f else 0f
+        val notesSet = notes + if (trimmed.second) setOf(FieldNote.LENGTH_TRIMMED) else emptySet()
+        val patternRelaxed = if (!primaryPattern) setOf(FieldNote.PATTERN_RELAXED) else emptySet()
+        val confidence = (baseConfidence - lengthPenalty - notes.count() * 0.05f)
+            .coerceIn(0.1f, 0.9f)
+        return FieldConfidence(
+            value = trimmed.first,
+            confidence = confidence,
+            source = FieldSource.OCR,
+            notes = notesSet + patternRelaxed
+        )
+    }
+
+    private fun enforceLength(field: String, value: String): Pair<String, Boolean> {
+        val limit = when (field) {
+            "sirimSerialNo" -> 12
+            "batchNo" -> 200
+            "brandTrademark" -> 1024
+            "model", "type", "size" -> 1500
+            "rating" -> 600
+            else -> 512
+        }
+        return if (value.length > limit) {
+            value.substring(0, min(limit, value.length)) to true
+        } else {
+            value to false
+        }
+    }
+
+    private fun correctCharacters(value: String): Pair<String, Set<FieldNote>> {
+        var corrected = value
+        val appliedNotes = mutableSetOf<FieldNote>()
+        characterCorrections.forEach { (wrong, correct) ->
+            if (corrected.indexOf(wrong, ignoreCase = false) >= 0) {
+                corrected = corrected.replace(wrong, correct)
+                appliedNotes += FieldNote.CORRECTED_CHARACTER
+            }
+        }
+        return corrected to appliedNotes
+    }
+
+    private fun collapseVerticalText(text: String): String {
+        val cleaned = text.replace("\uFF1A", ":")
+        val lines = cleaned.lines()
+        val verticalSegments = mutableListOf<String>()
+        var buffer = StringBuilder()
+        lines.forEach { line ->
+            val trimmed = line.trim()
+            if (trimmed.length == 1 && trimmed.firstOrNull()?.isLetterOrDigit() == true) {
+                buffer.append(trimmed)
+            } else {
+                if (buffer.length >= 4) {
+                    verticalSegments += buffer.toString()
+                }
+                buffer = StringBuilder()
+            }
+        }
+        if (buffer.length >= 4) {
+            verticalSegments += buffer.toString()
+        }
+        val augmented = cleaned + " " + verticalSegments.joinToString(" ")
+        return augmented.replace("\n", " ").replace("\\s+".toRegex(), " ").trim()
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/data/ocr/TesseractManager.kt
+++ b/app/src/main/java/com/sirim/scanner/data/ocr/TesseractManager.kt
@@ -1,0 +1,80 @@
+package com.sirim.scanner.data.ocr
+
+import android.content.Context
+import android.graphics.Bitmap
+import com.googlecode.tesseract.android.TessBaseAPI
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class TesseractManager(context: Context) {
+
+    private val appContext = context.applicationContext
+
+    private val baseDir: File = File(context.filesDir, "tesseract").apply { mkdirs() }
+    private val tessDataDir: File = File(baseDir, "tessdata").apply { mkdirs() }
+    private val mutex = Mutex()
+
+    private var tessBaseApi: TessBaseAPI? = null
+    private var initialised = false
+
+    suspend fun recognise(bitmap: Bitmap): String? = mutex.withLock {
+        if (!ensureEngine()) return null
+        val engine = tessBaseApi ?: return null
+        return try {
+            engine.setImage(bitmap)
+            engine.utF8Text?.takeIf { it.isNotBlank() }
+        } catch (error: Exception) {
+            null
+        } finally {
+            engine.clear()
+        }
+    }
+
+    private fun ensureEngine(): Boolean {
+        if (initialised) {
+            return tessBaseApi != null
+        }
+
+        val engine = TessBaseAPI()
+        val hasTrainedData = ensureTrainedDataExists()
+        val success = hasTrainedData && runCatching {
+            engine.init(baseDir.absolutePath, "eng")
+        }.getOrDefault(false)
+
+        if (success) {
+            engine.pageSegMode = TessBaseAPI.PageSegMode.PSM_AUTO
+            tessBaseApi = engine
+        } else {
+            engine.end()
+            tessBaseApi = null
+        }
+
+        initialised = true
+        return tessBaseApi != null
+    }
+
+    private fun ensureTrainedDataExists(): Boolean {
+        val trainedData = File(tessDataDir, "eng.traineddata")
+        if (trainedData.exists()) {
+            return true
+        }
+
+        return copyBundledModel(trainedData)
+    }
+
+    private fun copyBundledModel(destination: File): Boolean {
+        val assetName = "tessdata/eng.traineddata"
+        return runCatching {
+            appContext.assets.open(assetName)
+        }.mapCatching { stream ->
+            stream.use { input ->
+                FileOutputStream(destination).use { output ->
+                    input.copyTo(output)
+                }
+            }
+            destination.exists()
+        }.getOrElse { false }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/data/repository/SirimRepository.kt
+++ b/app/src/main/java/com/sirim/scanner/data/repository/SirimRepository.kt
@@ -1,0 +1,14 @@
+package com.sirim.scanner.data.repository
+
+import com.sirim.scanner.data.db.SirimRecord
+import kotlinx.coroutines.flow.Flow
+
+interface SirimRepository {
+    val records: Flow<List<SirimRecord>>
+    fun search(query: String): Flow<List<SirimRecord>>
+    suspend fun upsert(record: SirimRecord): Long
+    suspend fun delete(record: SirimRecord)
+    suspend fun getRecord(id: Long): SirimRecord?
+    suspend fun findBySerial(serial: String): SirimRecord?
+    suspend fun persistImage(bytes: ByteArray, extension: String = "jpg"): String
+}

--- a/app/src/main/java/com/sirim/scanner/data/repository/SirimRepositoryImpl.kt
+++ b/app/src/main/java/com/sirim/scanner/data/repository/SirimRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.sirim.scanner.data.repository
+
+import android.content.Context
+import com.sirim.scanner.data.db.SirimRecord
+import com.sirim.scanner.data.db.SirimRecordDao
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class SirimRepositoryImpl(
+    private val dao: SirimRecordDao,
+    private val context: Context
+) : SirimRepository {
+
+    private val fileMutex = Mutex()
+
+    override val records: Flow<List<SirimRecord>> = dao.getAllRecords()
+
+    override fun search(query: String): Flow<List<SirimRecord>> =
+        dao.searchRecords("%$query%")
+
+    override suspend fun upsert(record: SirimRecord): Long = dao.upsert(record)
+
+    override suspend fun delete(record: SirimRecord) {
+        record.imagePath?.let { path ->
+            runCatching { File(path).takeIf(File::exists)?.delete() }
+        }
+        dao.delete(record)
+    }
+
+    override suspend fun getRecord(id: Long): SirimRecord? = dao.getRecordById(id)
+
+    override suspend fun findBySerial(serial: String): SirimRecord? = dao.findBySerial(serial)
+
+    override suspend fun persistImage(bytes: ByteArray, extension: String): String {
+        val directory = File(context.filesDir, "captured")
+        if (!directory.exists()) directory.mkdirs()
+        return fileMutex.withLock {
+            val file = File(directory, "sirim_${System.currentTimeMillis()}.$extension")
+            FileOutputStream(file).use { output ->
+                output.write(bytes)
+            }
+            file.absolutePath
+        }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/data/validation/FieldValidator.kt
+++ b/app/src/main/java/com/sirim/scanner/data/validation/FieldValidator.kt
@@ -1,0 +1,102 @@
+package com.sirim.scanner.data.validation
+
+import com.sirim.scanner.data.ocr.FieldConfidence
+import com.sirim.scanner.data.ocr.FieldNote
+
+data class ValidationResult(
+    val sanitized: Map<String, FieldConfidence>,
+    val errors: Map<String, String>,
+    val warnings: Map<String, String>
+)
+
+object FieldValidator {
+
+    private val serialRegex = Regex("^(TEA\d{7}|T\d{9})$", RegexOption.IGNORE_CASE)
+    private val batchRegex = Regex("^[A-Z0-9-]{1,200}$", RegexOption.IGNORE_CASE)
+    private val alphaNumeric = Regex("^[A-Za-z0-9 .,&'\-\/]{1,1500}$")
+    private val ratingRegex = Regex("^(SAE\s*[0-9]{1,2}W-?[0-9]{1,2}|[A-Za-z0-9 .,&'\-\/]{1,600})$", RegexOption.IGNORE_CASE)
+    private val sizeRegex = Regex("^[0-9]+\s*(L|ML|LITRE|LTR|KG)$", RegexOption.IGNORE_CASE)
+
+    fun validate(fields: Map<String, FieldConfidence>): ValidationResult {
+        val sanitized = mutableMapOf<String, FieldConfidence>()
+        val errors = mutableMapOf<String, String>()
+        val warnings = mutableMapOf<String, String>()
+
+        fields.forEach { (key, confidence) ->
+            val trimmed = confidence.value.trim()
+            val updated = confidence.copy(value = trimmed)
+            when (key) {
+                "sirimSerialNo" -> handleSerial(updated, sanitized, errors, warnings)
+                "batchNo" -> handlePattern(updated, batchRegex, sanitized, warnings, key)
+                "brandTrademark", "model", "type" -> handlePattern(updated, alphaNumeric, sanitized, warnings, key)
+                "rating" -> handlePattern(updated, ratingRegex, sanitized, warnings, key)
+                "size" -> handlePattern(updated, sizeRegex, sanitized, warnings, key)
+                else -> sanitized[key] = updated
+            }
+            val notes = sanitized[key]?.notes ?: return@forEach
+            if (FieldNote.CONFLICT in notes) {
+                warnings.putIfAbsent(key, "Mismatch between QR data and OCR text")
+            }
+            if (FieldNote.CORRECTED_CHARACTER in notes && warnings[key] == null) {
+                warnings[key] = "Similar characters corrected (O↔0, I↔1, S↔5)"
+            }
+            if (FieldNote.LENGTH_TRIMMED in notes) {
+                warnings[key] = "Value truncated to fit allowed length"
+            }
+            if (FieldNote.PATTERN_RELAXED in notes && warnings[key] == null) {
+                warnings[key] = "Field matched using relaxed pattern"
+            }
+        }
+
+        if (!sanitized.containsKey("sirimSerialNo")) {
+            errors["sirimSerialNo"] = "Serial number missing or unreadable"
+        }
+
+        return ValidationResult(
+            sanitized = sanitized,
+            errors = errors,
+            warnings = warnings
+        )
+    }
+
+    private fun handleSerial(
+        confidence: FieldConfidence,
+        sanitized: MutableMap<String, FieldConfidence>,
+        errors: MutableMap<String, String>,
+        warnings: MutableMap<String, String>
+    ) {
+        val normalized = confidence.value.uppercase()
+        val cleaned = normalized.replace("-", "")
+        if (serialRegex.matches(cleaned)) {
+            val adjusted = confidence.copy(value = cleaned)
+            sanitized["sirimSerialNo"] = adjusted
+        } else {
+            val newNotes = confidence.notes + FieldNote.FORMAT_MISMATCH
+            sanitized["sirimSerialNo"] = confidence.copy(value = cleaned, confidence = confidence.confidence * 0.6f, notes = newNotes)
+            warnings["sirimSerialNo"] = "Serial number format could not be verified"
+        }
+    }
+
+    private fun handlePattern(
+        confidence: FieldConfidence,
+        regex: Regex,
+        sanitized: MutableMap<String, FieldConfidence>,
+        warnings: MutableMap<String, String>,
+        key: String
+    ) {
+        if (confidence.value.isEmpty()) return
+        val matches = regex.matches(confidence.value)
+        val updated = if (matches) confidence else confidence.copy(
+            confidence = confidence.confidence * 0.75f,
+            notes = confidence.notes + FieldNote.FORMAT_MISMATCH
+        )
+        sanitized[key] = updated
+        if (!matches) {
+            warnings[key] = "${prettyFieldName(key)} format may be invalid"
+        }
+    }
+
+    private fun prettyFieldName(field: String): String = field.replace(Regex("([A-Z])")) {
+        " " + it.value.lowercase()
+    }.trim().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+}

--- a/app/src/main/java/com/sirim/scanner/ui/common/FilterModels.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/common/FilterModels.kt
@@ -1,0 +1,18 @@
+package com.sirim.scanner.ui.common
+
+import java.util.concurrent.TimeUnit
+
+enum class VerifiedFilter {
+    ALL,
+    VERIFIED,
+    UNVERIFIED
+}
+
+enum class DateRangeFilter(val days: Long?) {
+    ALL(null),
+    LAST_7_DAYS(7),
+    LAST_30_DAYS(30)
+}
+
+fun DateRangeFilter.startTimestamp(now: Long = System.currentTimeMillis()): Long? =
+    days?.let { now - TimeUnit.DAYS.toMillis(it) }

--- a/app/src/main/java/com/sirim/scanner/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/dashboard/DashboardScreen.kt
@@ -1,0 +1,89 @@
+package com.sirim.scanner.ui.screens.dashboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sirim.scanner.data.db.SirimRecord
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DashboardScreen(
+    viewModel: DashboardViewModel,
+    navigateToScanner: () -> Unit,
+    navigateToRecords: () -> Unit,
+    navigateToExport: () -> Unit
+) {
+    val recentRecords by viewModel.recentRecords.collectAsState()
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("SIRIM Scanner Dashboard") }) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .padding(24.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = navigateToScanner
+                ) { Text("Scan Label") }
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = navigateToRecords
+                ) { Text("Records") }
+            }
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = navigateToExport
+            ) { Text("Export Data") }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Recent Records",
+                style = MaterialTheme.typography.titleMedium
+            )
+            recentRecords.forEach { record ->
+                RecentRecordCard(record = record)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentRecordCard(record: SirimRecord) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = "Serial: ${record.sirimSerialNo}")
+            Text(text = "Batch: ${record.batchNo}")
+            Text(text = "Brand: ${record.brandTrademark}")
+        }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/dashboard/DashboardViewModel.kt
@@ -1,0 +1,36 @@
+package com.sirim.scanner.ui.screens.dashboard
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.sirim.scanner.data.db.SirimRecord
+import com.sirim.scanner.data.repository.SirimRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class DashboardViewModel private constructor(
+    private val repository: SirimRepository
+) : ViewModel() {
+
+    private val _recentRecords = MutableStateFlow<List<SirimRecord>>(emptyList())
+    val recentRecords: StateFlow<List<SirimRecord>> = _recentRecords.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.records.collect { records ->
+                _recentRecords.value = records.take(5)
+            }
+        }
+    }
+
+    companion object {
+        fun Factory(repository: SirimRepository): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return DashboardViewModel(repository) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/export/ExportScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/export/ExportScreen.kt
@@ -1,0 +1,207 @@
+package com.sirim.scanner.ui.screens.export
+
+import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.sirim.scanner.data.export.ExportFormat
+import com.sirim.scanner.ui.common.DateRangeFilter
+import com.sirim.scanner.ui.common.VerifiedFilter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportScreen(
+    viewModel: ExportViewModel,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val isExporting by viewModel.isExporting.collectAsState()
+    val lastExportUri by viewModel.lastExportUri.collectAsState()
+    val lastFormat by viewModel.lastFormat.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
+    val shareLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { }
+
+    LaunchedEffect(lastExportUri) {
+        lastExportUri?.let { uri ->
+            context.grantUriPermission(
+                context.packageName,
+                uri,
+                android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Export Records") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            ExportFilterSection(
+                uiState = uiState,
+                onVerifiedChange = viewModel::setVerifiedFilter,
+                onBrandChange = viewModel::setBrandFilter,
+                onDateChange = viewModel::setDateRange,
+                onClear = viewModel::clearFilters
+            )
+
+            Text(
+                text = "Preparing ${uiState.filteredRecords.size} of ${uiState.totalRecords} records",
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            Button(
+                onClick = { viewModel.export(ExportFormat.Pdf) },
+                enabled = !isExporting && uiState.filteredRecords.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Export as PDF") }
+            Button(
+                onClick = { viewModel.export(ExportFormat.Excel) },
+                enabled = !isExporting && uiState.filteredRecords.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Export as Excel") }
+            Button(
+                onClick = { viewModel.export(ExportFormat.Csv) },
+                enabled = !isExporting && uiState.filteredRecords.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Export as CSV") }
+
+            if (lastExportUri != null) {
+                Text("Last export ready at: $lastExportUri")
+                Button(
+                    onClick = {
+                        val format = lastFormat ?: ExportFormat.Pdf
+                        val mime = when (format) {
+                            ExportFormat.Pdf -> "application/pdf"
+                            ExportFormat.Excel -> "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                            ExportFormat.Csv -> "text/csv"
+                        }
+                        val intent = Intent(Intent.ACTION_SEND).apply {
+                            type = mime
+                            putExtra(Intent.EXTRA_STREAM, lastExportUri)
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        val chooser = Intent.createChooser(intent, "Share export")
+                        shareLauncher.launch(chooser)
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Share Export")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExportFilterSection(
+    uiState: ExportUiState,
+    onVerifiedChange: (VerifiedFilter) -> Unit,
+    onBrandChange: (String?) -> Unit,
+    onDateChange: (DateRangeFilter) -> Unit,
+    onClear: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            VerifiedFilter.values().forEach { filter ->
+                FilterChip(
+                    selected = uiState.filters.verified == filter,
+                    onClick = { onVerifiedChange(filter) },
+                    label = { Text(filterLabel(filter)) }
+                )
+            }
+        }
+
+        if (uiState.availableBrands.isNotEmpty()) {
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                item {
+                    FilterChip(
+                        selected = uiState.filters.brand == null,
+                        onClick = { onBrandChange(null) },
+                        label = { Text("All Brands") }
+                    )
+                }
+                items(uiState.availableBrands) { brand ->
+                    FilterChip(
+                        selected = uiState.filters.brand.equals(brand, ignoreCase = true),
+                        onClick = { onBrandChange(brand) },
+                        label = { Text(brand) }
+                    )
+                }
+            }
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            DateRangeFilter.values().forEach { range ->
+                val selected = uiState.filters.dateRange == range
+                FilterChip(
+                    selected = selected,
+                    onClick = { onDateChange(range) },
+                    label = { Text(rangeLabel(range)) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = if (selected) {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.surface
+                        }
+                    )
+                )
+            }
+            TextButton(onClick = onClear) { Text("Reset") }
+        }
+    }
+}
+
+private fun filterLabel(filter: VerifiedFilter): String = when (filter) {
+    VerifiedFilter.ALL -> "All"
+    VerifiedFilter.VERIFIED -> "Verified"
+    VerifiedFilter.UNVERIFIED -> "Unverified"
+}
+
+private fun rangeLabel(range: DateRangeFilter): String = when (range) {
+    DateRangeFilter.ALL -> "All Dates"
+    DateRangeFilter.LAST_7_DAYS -> "Last 7 days"
+    DateRangeFilter.LAST_30_DAYS -> "Last 30 days"
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/export/ExportViewModel.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/export/ExportViewModel.kt
@@ -1,0 +1,120 @@
+package com.sirim.scanner.ui.screens.export
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.sirim.scanner.data.db.SirimRecord
+import com.sirim.scanner.data.export.ExportFormat
+import com.sirim.scanner.data.export.ExportManager
+import com.sirim.scanner.data.repository.SirimRepository
+import com.sirim.scanner.ui.common.DateRangeFilter
+import com.sirim.scanner.ui.common.VerifiedFilter
+import com.sirim.scanner.ui.common.startTimestamp
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ExportViewModel private constructor(
+    private val repository: SirimRepository,
+    private val exportManager: ExportManager
+) : ViewModel() {
+
+    private val allRecords: StateFlow<List<SirimRecord>> = repository.records
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    private val filters = MutableStateFlow(ExportFilters())
+
+    val uiState: StateFlow<ExportUiState> = combine(allRecords, filters) { records, filters ->
+        val start = filters.dateRange.startTimestamp()
+        val filtered = records.filter { record ->
+            val matchesVerified = when (filters.verified) {
+                VerifiedFilter.ALL -> true
+                VerifiedFilter.VERIFIED -> record.isVerified
+                VerifiedFilter.UNVERIFIED -> !record.isVerified
+            }
+            val matchesBrand = filters.brand?.let { record.brandTrademark.equals(it, ignoreCase = true) } ?: true
+            val matchesDate = start?.let { record.createdAt >= it } ?: true
+            matchesVerified && matchesBrand && matchesDate
+        }
+        val availableBrands = records.mapNotNull { it.brandTrademark.takeIf(String::isNotBlank) }
+            .distinct()
+            .sorted()
+        ExportUiState(
+            filteredRecords = filtered,
+            totalRecords = records.size,
+            filters = filters,
+            availableBrands = availableBrands
+        )
+    }.stateIn(viewModelScope, SharingStarted.Lazily, ExportUiState())
+
+    private val _lastExportUri = MutableStateFlow<Uri?>(null)
+    val lastExportUri: StateFlow<Uri?> = _lastExportUri.asStateFlow()
+
+    private val _isExporting = MutableStateFlow(false)
+    val isExporting: StateFlow<Boolean> = _isExporting.asStateFlow()
+
+    private val _lastFormat = MutableStateFlow<ExportFormat?>(null)
+    val lastFormat: StateFlow<ExportFormat?> = _lastFormat.asStateFlow()
+
+    fun export(format: ExportFormat) {
+        if (_isExporting.value) return
+        _isExporting.value = true
+        viewModelScope.launch {
+            val snapshot = uiState.value
+            val uri = when (format) {
+                ExportFormat.Pdf -> exportManager.exportToPdf(snapshot.filteredRecords)
+                ExportFormat.Excel -> exportManager.exportToExcel(snapshot.filteredRecords)
+                ExportFormat.Csv -> exportManager.exportToCsv(snapshot.filteredRecords)
+            }
+            _lastExportUri.value = uri
+            _lastFormat.value = format
+            _isExporting.value = false
+        }
+    }
+
+    fun setVerifiedFilter(filter: VerifiedFilter) {
+        filters.update { it.copy(verified = filter) }
+    }
+
+    fun setBrandFilter(brand: String?) {
+        filters.update { it.copy(brand = brand) }
+    }
+
+    fun setDateRange(range: DateRangeFilter) {
+        filters.update { it.copy(dateRange = range) }
+    }
+
+    fun clearFilters() {
+        filters.value = ExportFilters()
+    }
+
+    companion object {
+        fun Factory(
+            repository: SirimRepository,
+            exportManager: ExportManager
+        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return ExportViewModel(repository, exportManager) as T
+            }
+        }
+    }
+}
+
+data class ExportUiState(
+    val filteredRecords: List<SirimRecord> = emptyList(),
+    val totalRecords: Int = 0,
+    val filters: ExportFilters = ExportFilters(),
+    val availableBrands: List<String> = emptyList()
+)
+
+data class ExportFilters(
+    val verified: VerifiedFilter = VerifiedFilter.ALL,
+    val brand: String? = null,
+    val dateRange: DateRangeFilter = DateRangeFilter.ALL
+)

--- a/app/src/main/java/com/sirim/scanner/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/login/LoginScreen.kt
@@ -1,0 +1,80 @@
+package com.sirim.scanner.ui.screens.login
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginScreen(
+    viewModel: LoginViewModel,
+    onAuthenticated: () -> Unit
+) {
+    val username by viewModel.username.collectAsState()
+    val password by viewModel.password.collectAsState()
+    val error by viewModel.error.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(error) {
+        error?.let { snackbarHostState.showSnackbar(message = it) }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(text = "SIRIM Scanner Login") })
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .padding(24.dp)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            OutlinedTextField(
+                value = username,
+                onValueChange = viewModel::onUsernameChanged,
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Username") }
+            )
+            OutlinedTextField(
+                value = password,
+                onValueChange = viewModel::onPasswordChanged,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation()
+            )
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
+                onClick = { viewModel.authenticate(onAuthenticated) }
+            ) {
+                Text(text = "Login")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/login/LoginViewModel.kt
@@ -1,0 +1,47 @@
+package com.sirim.scanner.ui.screens.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class LoginViewModel private constructor() : ViewModel() {
+
+    private val _username = MutableStateFlow("")
+    val username: StateFlow<String> = _username.asStateFlow()
+
+    private val _password = MutableStateFlow("")
+    val password: StateFlow<String> = _password.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun onUsernameChanged(value: String) {
+        _username.value = value
+        _error.value = null
+    }
+
+    fun onPasswordChanged(value: String) {
+        _password.value = value
+        _error.value = null
+    }
+
+    fun authenticate(onSuccess: () -> Unit) {
+        if (_username.value == "admin" && _password.value == "admin") {
+            _error.value = null
+            onSuccess()
+        } else {
+            _error.value = "Invalid credentials"
+        }
+    }
+
+    companion object {
+        fun Factory(): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return LoginViewModel() as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/records/RecordFormScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/records/RecordFormScreen.kt
@@ -1,0 +1,179 @@
+package com.sirim.scanner.ui.screens.records
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.sirim.scanner.data.db.SirimRecord
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecordFormScreen(
+    viewModel: RecordViewModel,
+    onSaved: () -> Unit,
+    onBack: () -> Unit,
+    recordId: Long? = null
+) {
+    val serialState = remember { mutableStateOf(TextFieldValue()) }
+    val batchState = remember { mutableStateOf(TextFieldValue()) }
+    val brandState = remember { mutableStateOf(TextFieldValue()) }
+    val modelState = remember { mutableStateOf(TextFieldValue()) }
+    val typeState = remember { mutableStateOf(TextFieldValue()) }
+    val ratingState = remember { mutableStateOf(TextFieldValue()) }
+    val sizeState = remember { mutableStateOf(TextFieldValue()) }
+
+    LaunchedEffect(recordId) {
+        recordId?.let { id ->
+            viewModel.loadRecord(id)
+        } ?: run {
+            viewModel.resetActiveRecord()
+            viewModel.clearFormError()
+            serialState.value = TextFieldValue("")
+            batchState.value = TextFieldValue("")
+            brandState.value = TextFieldValue("")
+            modelState.value = TextFieldValue("")
+            typeState.value = TextFieldValue("")
+            ratingState.value = TextFieldValue("")
+            sizeState.value = TextFieldValue("")
+        }
+    }
+
+    val activeRecord by viewModel.activeRecord.collectAsState()
+    val formError by viewModel.formError.collectAsState()
+
+    LaunchedEffect(activeRecord?.id) {
+        activeRecord?.let { record ->
+            serialState.value = TextFieldValue(record.sirimSerialNo)
+            batchState.value = TextFieldValue(record.batchNo)
+            brandState.value = TextFieldValue(record.brandTrademark)
+            modelState.value = TextFieldValue(record.model)
+            typeState.value = TextFieldValue(record.type)
+            ratingState.value = TextFieldValue(record.rating)
+            sizeState.value = TextFieldValue(record.size)
+            viewModel.clearFormError()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Record Form") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedTextField(
+                value = serialState.value,
+                onValueChange = {
+                    serialState.value = it
+                    viewModel.clearFormError()
+                },
+                label = { Text("SIRIM Serial No.") },
+                isError = formError != null,
+                supportingText = {
+                    formError?.let { message ->
+                        Text(text = message, color = MaterialTheme.colorScheme.error)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = batchState.value,
+                onValueChange = { batchState.value = it },
+                label = { Text("Batch No.") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = brandState.value,
+                onValueChange = { brandState.value = it },
+                label = { Text("Brand/Trademark") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = modelState.value,
+                onValueChange = { modelState.value = it },
+                label = { Text("Model") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = typeState.value,
+                onValueChange = { typeState.value = it },
+                label = { Text("Type") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = ratingState.value,
+                onValueChange = { ratingState.value = it },
+                label = { Text("Rating") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = sizeState.value,
+                onValueChange = { sizeState.value = it },
+                label = { Text("Size") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Button(
+                onClick = {
+                    val record = activeRecord?.copy(
+                        sirimSerialNo = serialState.value.text,
+                        batchNo = batchState.value.text,
+                        brandTrademark = brandState.value.text,
+                        model = modelState.value.text,
+                        type = typeState.value.text,
+                        rating = ratingState.value.text,
+                        size = sizeState.value.text
+                    ) ?: SirimRecord(
+                        sirimSerialNo = serialState.value.text,
+                        batchNo = batchState.value.text,
+                        brandTrademark = brandState.value.text,
+                        model = modelState.value.text,
+                        type = typeState.value.text,
+                        rating = ratingState.value.text,
+                        size = sizeState.value.text,
+                        imagePath = null
+                    )
+                    viewModel.createOrUpdate(record) {
+                        onSaved()
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Save Record")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/records/RecordListScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/records/RecordListScreen.kt
@@ -1,0 +1,221 @@
+package com.sirim.scanner.ui.screens.records
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sirim.scanner.data.db.SirimRecord
+import com.sirim.scanner.ui.common.DateRangeFilter
+import com.sirim.scanner.ui.common.VerifiedFilter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecordListScreen(
+    viewModel: RecordViewModel,
+    onAdd: () -> Unit,
+    onEdit: (SirimRecord) -> Unit,
+    onBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val records = uiState.records
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Records") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Button(
+                onClick = onAdd,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Add Record") }
+
+            OutlinedTextField(
+                value = uiState.query,
+                onValueChange = viewModel::updateSearchQuery,
+                label = { Text("Search records") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            FilterSection(
+                uiState = uiState,
+                onVerifiedChange = viewModel::setVerifiedFilter,
+                onBrandChange = viewModel::setBrandFilter,
+                onDateChange = viewModel::setDateRange,
+                onClear = viewModel::clearFilters
+            )
+
+            Text(
+                text = "Showing ${records.size} of ${uiState.totalRecords} records",
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            if (records.isEmpty()) {
+                Text(
+                    text = "No records match the current filters.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(records, key = { it.id }) { record ->
+                        RecordListItem(
+                            record = record,
+                            onEdit = { onEdit(record) },
+                            onDelete = { viewModel.delete(record) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterSection(
+    uiState: RecordListUiState,
+    onVerifiedChange: (VerifiedFilter) -> Unit,
+    onBrandChange: (String?) -> Unit,
+    onDateChange: (DateRangeFilter) -> Unit,
+    onClear: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            VerifiedFilter.values().forEach { filter ->
+                FilterChip(
+                    selected = uiState.filters.verified == filter,
+                    onClick = { onVerifiedChange(filter) },
+                    label = { Text(filterLabel(filter)) }
+                )
+            }
+        }
+
+        if (uiState.availableBrands.isNotEmpty()) {
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                item {
+                    FilterChip(
+                        selected = uiState.filters.brand == null,
+                        onClick = { onBrandChange(null) },
+                        label = { Text("All Brands") }
+                    )
+                }
+                items(uiState.availableBrands) { brand ->
+                    FilterChip(
+                        selected = uiState.filters.brand.equals(brand, ignoreCase = true),
+                        onClick = { onBrandChange(brand) },
+                        label = { Text(brand) }
+                    )
+                }
+            }
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            DateRangeFilter.values().forEach { range ->
+                val selected = uiState.filters.dateRange == range
+                FilterChip(
+                    selected = selected,
+                    onClick = { onDateChange(range) },
+                    label = { Text(rangeLabel(range)) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = if (selected) {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.surface
+                        }
+                    )
+                )
+            }
+            Spacer(modifier = Modifier.weight(1f, fill = true))
+            TextButton(onClick = onClear) {
+                Text("Reset")
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecordListItem(
+    record: SirimRecord,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onEdit)
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(text = record.sirimSerialNo, style = MaterialTheme.typography.titleMedium)
+                Text(text = record.brandTrademark, style = MaterialTheme.typography.bodyMedium)
+                Text(text = record.model, style = MaterialTheme.typography.bodySmall)
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.Delete, contentDescription = "Delete")
+            }
+        }
+    }
+}
+
+private fun filterLabel(filter: VerifiedFilter): String = when (filter) {
+    VerifiedFilter.ALL -> "All"
+    VerifiedFilter.VERIFIED -> "Verified"
+    VerifiedFilter.UNVERIFIED -> "Unverified"
+}
+
+private fun rangeLabel(range: DateRangeFilter): String = when (range) {
+    DateRangeFilter.ALL -> "All Dates"
+    DateRangeFilter.LAST_7_DAYS -> "Last 7 days"
+    DateRangeFilter.LAST_30_DAYS -> "Last 30 days"
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/records/RecordViewModel.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/records/RecordViewModel.kt
@@ -1,0 +1,158 @@
+package com.sirim.scanner.ui.screens.records
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.sirim.scanner.data.db.SirimRecord
+import com.sirim.scanner.data.repository.SirimRepository
+import com.sirim.scanner.ui.common.DateRangeFilter
+import com.sirim.scanner.ui.common.VerifiedFilter
+import com.sirim.scanner.ui.common.startTimestamp
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class RecordViewModel private constructor(
+    private val repository: SirimRepository
+) : ViewModel() {
+
+    private val allRecords: StateFlow<List<SirimRecord>> = repository.records
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    private val searchQuery = MutableStateFlow("")
+    private val filters = MutableStateFlow(RecordFilters())
+
+    val uiState: StateFlow<RecordListUiState> = combine(allRecords, searchQuery, filters) { records, query, filters ->
+        val normalizedQuery = query.trim()
+        val availableBrands = records.mapNotNull { it.brandTrademark.takeIf(String::isNotBlank) }
+            .distinct()
+            .sorted()
+        val startTimestamp = filters.dateRange.startTimestamp()
+        val filteredRecords = records.filter { record ->
+            val matchesQuery = if (normalizedQuery.isBlank()) {
+                true
+            } else {
+                listOf(
+                    record.sirimSerialNo,
+                    record.batchNo,
+                    record.brandTrademark,
+                    record.model,
+                    record.type,
+                    record.rating,
+                    record.size
+                ).any { value -> value.contains(normalizedQuery, ignoreCase = true) }
+            }
+            val matchesVerified = when (filters.verified) {
+                VerifiedFilter.ALL -> true
+                VerifiedFilter.VERIFIED -> record.isVerified
+                VerifiedFilter.UNVERIFIED -> !record.isVerified
+            }
+            val matchesBrand = filters.brand?.let { record.brandTrademark.equals(it, ignoreCase = true) } ?: true
+            val matchesDate = startTimestamp?.let { record.createdAt >= it } ?: true
+            matchesQuery && matchesVerified && matchesBrand && matchesDate
+        }
+        RecordListUiState(
+            records = filteredRecords,
+            availableBrands = availableBrands,
+            query = normalizedQuery,
+            filters = filters,
+            totalRecords = records.size
+        )
+    }.stateIn(viewModelScope, SharingStarted.Lazily, RecordListUiState())
+
+    private val _activeRecord = MutableStateFlow<SirimRecord?>(null)
+    val activeRecord: StateFlow<SirimRecord?> = _activeRecord.asStateFlow()
+
+    private val _formError = MutableStateFlow<String?>(null)
+    val formError: StateFlow<String?> = _formError.asStateFlow()
+
+    fun loadRecord(id: Long) {
+        viewModelScope.launch {
+            _activeRecord.value = repository.getRecord(id)
+            _formError.value = null
+        }
+    }
+
+    fun resetActiveRecord() {
+        _activeRecord.value = null
+        _formError.value = null
+    }
+
+    fun createOrUpdate(record: SirimRecord, onSaved: (Long) -> Unit) {
+        viewModelScope.launch {
+            val normalizedSerial = record.sirimSerialNo.trim()
+            if (normalizedSerial.isBlank()) {
+                _formError.value = "SIRIM serial number is required"
+                return@launch
+            }
+            val existing = repository.findBySerial(normalizedSerial)
+            if (existing != null && existing.id != record.id) {
+                _formError.value = "Serial $normalizedSerial already exists"
+                return@launch
+            }
+            val sanitized = record.copy(sirimSerialNo = normalizedSerial)
+            val id = repository.upsert(sanitized)
+            _activeRecord.value = repository.getRecord(id)
+            _formError.value = null
+            onSaved(id)
+        }
+    }
+
+    fun delete(record: SirimRecord) {
+        viewModelScope.launch {
+            repository.delete(record)
+        }
+    }
+
+    fun updateSearchQuery(query: String) {
+        searchQuery.value = query
+    }
+
+    fun setVerifiedFilter(filter: VerifiedFilter) {
+        filters.update { it.copy(verified = filter) }
+    }
+
+    fun setBrandFilter(brand: String?) {
+        filters.update { it.copy(brand = brand) }
+    }
+
+    fun setDateRange(range: DateRangeFilter) {
+        filters.update { it.copy(dateRange = range) }
+    }
+
+    fun clearFilters() {
+        filters.value = RecordFilters()
+    }
+
+    fun clearFormError() {
+        _formError.value = null
+    }
+
+    companion object {
+        fun Factory(repository: SirimRepository): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return RecordViewModel(repository) as T
+                }
+            }
+    }
+}
+
+data class RecordListUiState(
+    val records: List<SirimRecord> = emptyList(),
+    val availableBrands: List<String> = emptyList(),
+    val query: String = "",
+    val filters: RecordFilters = RecordFilters(),
+    val totalRecords: Int = 0
+)
+
+data class RecordFilters(
+    val verified: VerifiedFilter = VerifiedFilter.ALL,
+    val brand: String? = null,
+    val dateRange: DateRangeFilter = DateRangeFilter.ALL
+)

--- a/app/src/main/java/com/sirim/scanner/ui/screens/scanner/ScannerScreen.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/scanner/ScannerScreen.kt
@@ -1,0 +1,538 @@
+package com.sirim.scanner.ui.screens.scanner
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.view.HapticFeedbackConstants
+import android.view.MotionEvent
+import android.view.View
+import androidx.camera.core.Camera
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.FocusMeteringAction
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.MeteringPointFactory
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Bolt
+import androidx.compose.material.icons.rounded.FlashOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import com.sirim.scanner.data.ocr.FieldConfidence
+import com.sirim.scanner.data.ocr.SirimLabelParser
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScannerScreen(
+    viewModel: ScannerViewModel,
+    onBack: () -> Unit,
+    onRecordSaved: (Long) -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+    val status by viewModel.status.collectAsState()
+    val fields by viewModel.extractedFields.collectAsState()
+    val warnings by viewModel.validationWarnings.collectAsState()
+    val errors by viewModel.validationErrors.collectAsState()
+    val lastRecordId by viewModel.lastResultId.collectAsState()
+    val batchUiState by viewModel.batchUiState.collectAsState()
+    val hasCameraPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    val showDuplicateDialog = rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(status.state) {
+        if (status.state == ScanState.Duplicate) {
+            showDuplicateDialog.value = true
+        }
+    }
+
+    LaunchedEffect(lastRecordId) {
+        lastRecordId?.let(onRecordSaved)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Scanner") },
+                navigationIcon = {
+                    TextButton(onClick = onBack) { Text("Back") }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            StatusCard(status = status)
+            BatchControls(
+                uiState = batchUiState,
+                onToggle = viewModel::setBatchMode,
+                onSave = viewModel::saveBatch,
+                onClear = viewModel::clearBatchQueue
+            )
+            if (hasCameraPermission) {
+                CameraPreview(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    lifecycleOwner = lifecycleOwner,
+                    viewModel = viewModel,
+                    status = status
+                )
+            } else {
+                Text("Camera permission is required to scan labels.")
+            }
+
+            ExtractedFieldsPanel(
+                fields = fields,
+                warnings = warnings,
+                errors = errors
+            )
+        }
+    }
+
+    if (showDuplicateDialog.value) {
+        AlertDialog(
+            onDismissRequest = { showDuplicateDialog.value = false },
+            title = { Text("Duplicate Serial Detected") },
+            text = { Text("This serial number already exists in the database. Review before saving again.") },
+            confirmButton = {
+                TextButton(onClick = { showDuplicateDialog.value = false }) {
+                    Text("OK")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun BatchControls(
+    uiState: BatchUiState,
+    onToggle: (Boolean) -> Unit,
+    onSave: () -> Unit,
+    onClear: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    Text("Batch mode", style = MaterialTheme.typography.titleSmall)
+                    Text("Queued ${uiState.queued.size}", style = MaterialTheme.typography.bodySmall)
+                }
+                Switch(checked = uiState.enabled, onCheckedChange = onToggle)
+            }
+
+            if (uiState.queued.isNotEmpty()) {
+                LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(uiState.queued, key = { it.serial + it.capturedAt }) { item ->
+                        AssistChip(
+                            onClick = {},
+                            label = {
+                                Text("${item.serial} • ${(item.confidence * 100).roundToInt()}%")
+                            }
+                        )
+                    }
+                }
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+                Button(
+                    onClick = onSave,
+                    enabled = uiState.enabled && uiState.queued.isNotEmpty(),
+                    modifier = Modifier.weight(1f)
+                ) { Text("Save Batch") }
+                TextButton(
+                    onClick = onClear,
+                    enabled = uiState.queued.isNotEmpty(),
+                    modifier = Modifier.weight(1f)
+                ) { Text("Clear Queue") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusCard(status: ScanStatus) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(
+                text = status.message.ifBlank { "Point the camera at the SIRIM label" },
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            LinearProgressIndicator(
+                progress = { status.confidence.coerceIn(0f, 1f) },
+                modifier = Modifier.fillMaxWidth(),
+                trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
+                color = when {
+                    status.confidence >= 0.8f -> MaterialTheme.colorScheme.primary
+                    status.confidence >= 0.5f -> MaterialTheme.colorScheme.secondary
+                    else -> MaterialTheme.colorScheme.error
+                }
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text("Confidence ${(status.confidence * 100).toInt()}%", style = MaterialTheme.typography.bodyMedium)
+                Text("Frames ${status.frames}", style = MaterialTheme.typography.bodyMedium)
+                Text("State ${status.state.name}", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExtractedFieldsPanel(
+    fields: Map<String, FieldConfidence>,
+    warnings: Map<String, String>,
+    errors: Map<String, String>
+) {
+    if (fields.isEmpty() && warnings.isEmpty() && errors.isEmpty()) {
+        return
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 160.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text("Recognized Fields", style = MaterialTheme.typography.titleMedium)
+            fields.forEach { (key, confidence) ->
+                FieldRow(
+                    label = SirimLabelParser.prettifyKey(key),
+                    confidence = confidence,
+                    warning = warnings[key],
+                    error = errors[key]
+                )
+            }
+            if (warnings.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                warnings.forEach { (field, message) ->
+                    WarningRow(title = "Warning for ${SirimLabelParser.prettifyKey(field)}", message = message)
+                }
+            }
+            if (errors.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                errors.forEach { (field, message) ->
+                    WarningRow(title = "Error for ${SirimLabelParser.prettifyKey(field)}", message = message, color = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FieldRow(
+    label: String,
+    confidence: FieldConfidence,
+    warning: String?,
+    error: String?
+) {
+    val indicatorColor = when {
+        error != null -> MaterialTheme.colorScheme.error
+        confidence.confidence >= 0.8f -> MaterialTheme.colorScheme.primary
+        confidence.confidence >= 0.5f -> MaterialTheme.colorScheme.secondary
+        else -> MaterialTheme.colorScheme.tertiary
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.surface,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(12.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Canvas(modifier = Modifier.size(12.dp)) {
+                drawCircle(color = indicatorColor)
+            }
+            Text(label, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Spacer(modifier = Modifier.weight(1f))
+            Text("${(confidence.confidence * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(confidence.value.ifBlank { "—" }, style = MaterialTheme.typography.bodyMedium)
+        AnimatedVisibility(visible = warning != null || error != null, enter = fadeIn(), exit = fadeOut()) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                warning?.let { Text(it, style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.tertiary)) }
+                error?.let { Text(it, style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.error)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WarningRow(title: String, message: String, color: Color = MaterialTheme.colorScheme.tertiary) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(title, style = MaterialTheme.typography.labelMedium.copy(color = color, fontWeight = FontWeight.SemiBold))
+        Text(message, style = MaterialTheme.typography.bodySmall.copy(color = color))
+    }
+}
+
+@Composable
+private fun CameraPreview(
+    modifier: Modifier = Modifier,
+    lifecycleOwner: LifecycleOwner,
+    viewModel: ScannerViewModel,
+    status: ScanStatus
+) {
+    val context = LocalContext.current
+    val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
+    val previewView = remember {
+        PreviewView(context).apply {
+            scaleType = PreviewView.ScaleType.FILL_CENTER
+        }
+    }
+    val camera = remember { mutableStateOf<Camera?>(null) }
+    val flashEnabled = rememberSaveable { mutableStateOf(false) }
+    val zoomRatio = rememberSaveable { mutableFloatStateOf(1f) }
+    val exposureCompensation = rememberSaveable { mutableFloatStateOf(0f) }
+
+    DisposableEffect(lifecycleOwner) {
+        val executor = ContextCompat.getMainExecutor(context)
+        val listener = Runnable {
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = Preview.Builder().build().also {
+                it.setSurfaceProvider(previewView.surfaceProvider)
+            }
+            val analysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build().apply {
+                    setAnalyzer(executor) { image ->
+                        viewModel.analyzeImage(image)
+                    }
+                }
+            val boundCamera = cameraProvider.bindToLifecycle(
+                lifecycleOwner,
+                CameraSelector.DEFAULT_BACK_CAMERA,
+                preview,
+                analysis
+            )
+            camera.value = boundCamera
+            enableTapToFocus(previewView, boundCamera.cameraControl, previewView.meteringPointFactory)
+        }
+        cameraProviderFuture.addListener(listener, executor)
+
+        onDispose {
+            runCatching { cameraProviderFuture.get().unbindAll() }
+        }
+    }
+
+    LaunchedEffect(flashEnabled.value) {
+        camera.value?.cameraControl?.enableTorch(flashEnabled.value)
+    }
+
+    LaunchedEffect(zoomRatio.floatValue) {
+        camera.value?.cameraControl?.setZoomRatio(zoomRatio.floatValue.coerceAtLeast(1f))
+    }
+
+    LaunchedEffect(exposureCompensation.floatValue) {
+        camera.value?.cameraControl?.setExposureCompensationIndex(exposureCompensation.floatValue.toInt())
+    }
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(modifier = Modifier.weight(1f)) {
+            AndroidView(
+                factory = { previewView },
+                modifier = Modifier.fillMaxSize()
+            )
+            ScannerOverlay(status = status)
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { flashEnabled.value = !flashEnabled.value }) {
+                Icon(
+                    imageVector = if (flashEnabled.value) Icons.Rounded.Bolt else Icons.Rounded.FlashOff,
+                    contentDescription = if (flashEnabled.value) "Flash on" else "Flash off"
+                )
+            }
+            ZoomSlider(
+                value = zoomRatio.floatValue,
+                onValueChange = { zoomRatio.floatValue = it },
+                range = 1f..4f,
+                label = "Zoom",
+                steps = 8
+            )
+        }
+        camera.value?.cameraInfo?.exposureState?.let { exposureState ->
+            ZoomSlider(
+                value = exposureCompensation.floatValue,
+                onValueChange = {
+                    val rounded = it.roundToInt().toFloat()
+                    exposureCompensation.floatValue = rounded.coerceIn(
+                        exposureState.exposureCompensationRange.lower.toFloat(),
+                        exposureState.exposureCompensationRange.upper.toFloat()
+                    )
+                },
+                range = exposureState.exposureCompensationRange.lower.toFloat()..exposureState.exposureCompensationRange.upper.toFloat(),
+                label = "Exposure",
+                steps = (exposureState.exposureCompensationRange.upper - exposureState.exposureCompensationRange.lower)
+            )
+        }
+    }
+}
+
+private fun enableTapToFocus(
+    previewView: PreviewView,
+    cameraControl: androidx.camera.core.CameraControl,
+    meteringPointFactory: MeteringPointFactory
+) {
+    previewView.afterMeasured {
+        setOnTouchListener { _: View, event: MotionEvent ->
+            if (event.action != MotionEvent.ACTION_UP) return@setOnTouchListener true
+            val point = meteringPointFactory.createPoint(event.x, event.y)
+            val action = FocusMeteringAction.Builder(point)
+                .setAutoCancelDuration(3, TimeUnit.SECONDS)
+                .build()
+            cameraControl.startFocusAndMetering(action)
+            performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+            true
+        }
+    }
+}
+
+@Composable
+private fun ZoomSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    range: ClosedFloatingPointRange<Float>,
+    label: String,
+    modifier: Modifier = Modifier,
+    steps: Int = 0
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(label, style = MaterialTheme.typography.labelMedium)
+            Text(String.format("%.1f", value), style = MaterialTheme.typography.bodySmall)
+        }
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = range,
+            steps = steps
+        )
+    }
+}
+
+@Composable
+private fun ScannerOverlay(status: ScanStatus) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        val padding = 48.dp.toPx()
+        val width = size.width - padding * 2
+        val height = size.height - padding * 2
+        drawRoundRect(
+            color = when (status.state) {
+                ScanState.Ready, ScanState.Persisted -> Color(0xFF4CAF50)
+                ScanState.Partial -> Color(0xFFFFC107)
+                ScanState.Error, ScanState.Duplicate -> Color(0xFFF44336)
+                else -> Color.White.copy(alpha = 0.6f)
+            },
+            topLeft = androidx.compose.ui.geometry.Offset(padding, padding),
+            size = androidx.compose.ui.geometry.Size(width, height),
+            style = Stroke(width = 4.dp.toPx(), cap = StrokeCap.Round)
+        )
+    }
+}
+
+private fun View.afterMeasured(block: View.() -> Unit) {
+    if (width > 0 && height > 0) {
+        block()
+    } else {
+        addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
+            override fun onLayoutChange(
+                v: View?,
+                left: Int,
+                top: Int,
+                right: Int,
+                bottom: Int,
+                oldLeft: Int,
+                oldTop: Int,
+                oldRight: Int,
+                oldBottom: Int
+            ) {
+                if (width > 0 && height > 0) {
+                    removeOnLayoutChangeListener(this)
+                    block()
+                }
+            }
+        })
+    }
+}

--- a/app/src/main/java/com/sirim/scanner/ui/screens/scanner/ScannerViewModel.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/screens/scanner/ScannerViewModel.kt
@@ -1,0 +1,302 @@
+package com.sirim.scanner.ui.screens.scanner
+
+import androidx.camera.core.ImageProxy
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.sirim.scanner.data.db.SirimRecord
+import com.sirim.scanner.data.ocr.FieldConfidence
+import com.sirim.scanner.data.ocr.LabelAnalyzer
+import com.sirim.scanner.data.ocr.OcrResult
+import com.sirim.scanner.data.ocr.toJpegByteArray
+import com.sirim.scanner.data.repository.SirimRepository
+import com.sirim.scanner.data.validation.FieldValidator
+import com.sirim.scanner.data.validation.ValidationResult
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ScannerViewModel private constructor(
+    private val repository: SirimRepository,
+    private val analyzer: LabelAnalyzer,
+    private val appScope: CoroutineScope
+) : ViewModel() {
+
+    private val processing = AtomicBoolean(false)
+
+    private val _extractedFields = MutableStateFlow<Map<String, FieldConfidence>>(emptyMap())
+    val extractedFields: StateFlow<Map<String, FieldConfidence>> = _extractedFields.asStateFlow()
+
+    private val _validationWarnings = MutableStateFlow<Map<String, String>>(emptyMap())
+    val validationWarnings: StateFlow<Map<String, String>> = _validationWarnings.asStateFlow()
+
+    private val _validationErrors = MutableStateFlow<Map<String, String>>(emptyMap())
+    val validationErrors: StateFlow<Map<String, String>> = _validationErrors.asStateFlow()
+
+    private val _status = MutableStateFlow(ScanStatus())
+    val status: StateFlow<ScanStatus> = _status.asStateFlow()
+
+    private val _lastResultId = MutableStateFlow<Long?>(null)
+    val lastResultId: StateFlow<Long?> = _lastResultId.asStateFlow()
+
+    private val _batchMode = MutableStateFlow(false)
+    private val _batchQueue = MutableStateFlow<List<PendingRecord>>(emptyList())
+
+    val batchUiState: StateFlow<BatchUiState> = combine(_batchMode, _batchQueue) { enabled, queue ->
+        BatchUiState(
+            enabled = enabled,
+            queued = queue.map { BatchQueueItem(it.serial, it.timestamp, it.captureConfidence) }
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, BatchUiState())
+
+    fun setBatchMode(enabled: Boolean) {
+        if (_batchMode.value == enabled) return
+        _batchMode.value = enabled
+        _status.value = _status.value.copy(
+            state = if (enabled) ScanState.Ready else ScanState.Idle,
+            message = if (enabled) "Batch mode enabled" else "Batch mode disabled"
+        )
+    }
+
+    fun clearBatchQueue() {
+        if (_batchQueue.value.isEmpty()) return
+        _batchQueue.value = emptyList()
+        _status.value = _status.value.copy(state = ScanState.Idle, message = "Batch queue cleared")
+    }
+
+    fun saveBatch() {
+        val queued = _batchQueue.value
+        if (queued.isEmpty()) {
+            _status.value = _status.value.copy(message = "Batch queue is empty")
+            return
+        }
+        appScope.launch {
+            val savedIds = mutableListOf<Long>()
+            val skippedSerials = mutableListOf<String>()
+            var totalConfidence = 0f
+            queued.forEach { pending ->
+                val duplicate = repository.findBySerial(pending.serial)
+                if (duplicate != null) {
+                    skippedSerials += pending.serial
+                    return@forEach
+                }
+                val imagePath = pending.imageBytes?.let { repository.persistImage(it) }
+                val record = pending.toRecord(imagePath)
+                val id = repository.upsert(record)
+                savedIds += id
+                totalConfidence += pending.captureConfidence
+            }
+            _batchQueue.value = emptyList()
+            _batchMode.value = false
+            if (savedIds.isNotEmpty()) {
+                _lastResultId.value = savedIds.last()
+            }
+            val message = when {
+                savedIds.isNotEmpty() && skippedSerials.isNotEmpty() ->
+                    "${savedIds.size} saved, ${skippedSerials.size} duplicates skipped"
+                savedIds.isNotEmpty() -> "Batch saved (${savedIds.size} records)"
+                skippedSerials.isNotEmpty() -> "Skipped duplicates: ${skippedSerials.joinToString()}"
+                else -> "No records saved"
+            }
+            val averageConfidence = if (savedIds.isNotEmpty()) {
+                (totalConfidence / savedIds.size).coerceIn(0f, 1f)
+            } else {
+                _status.value.confidence
+            }
+            _status.value = _status.value.copy(
+                state = if (skippedSerials.isEmpty()) ScanState.Persisted else ScanState.Duplicate,
+                message = message,
+                confidence = averageConfidence
+            )
+        }
+    }
+
+    fun analyzeImage(imageProxy: ImageProxy) {
+        if (!processing.compareAndSet(false, true)) {
+            imageProxy.close()
+            return
+        }
+        _status.value = _status.value.copy(state = ScanState.Scanning, message = "Analyzing frame...", confidence = 0f)
+        viewModelScope.launch {
+            try {
+                when (val result = analyzer.analyze(imageProxy)) {
+                    is OcrResult.Success -> handleResult(result, autoPersist = true)
+                    is OcrResult.Partial -> handleResult(result, autoPersist = false)
+                    OcrResult.Empty -> {
+                        _status.value = ScanStatus(state = ScanState.Idle, message = "Align the label within the guide")
+                        _extractedFields.value = emptyMap()
+                        _validationWarnings.value = emptyMap()
+                        _validationErrors.value = emptyMap()
+                    }
+                }
+            } catch (ex: Exception) {
+                _status.value = ScanStatus(state = ScanState.Error, message = "Scan failed: ${ex.message ?: "Unknown error"}")
+            } finally {
+                imageProxy.close()
+                processing.set(false)
+            }
+        }
+    }
+
+    private suspend fun handleResult(result: OcrResult, autoPersist: Boolean) {
+        val fields = when (result) {
+            is OcrResult.Success -> result.fields
+            is OcrResult.Partial -> result.fields
+            else -> emptyMap()
+        }
+        if (fields.isEmpty()) {
+            _status.value = ScanStatus(state = ScanState.Scanning, message = "Still searching for readable text")
+            return
+        }
+
+        val validation = FieldValidator.validate(fields)
+        _extractedFields.value = validation.sanitized
+        _validationWarnings.value = validation.warnings
+        _validationErrors.value = validation.errors
+
+        val baseStatus = when (result) {
+            is OcrResult.Success -> ScanState.Ready
+            is OcrResult.Partial -> ScanState.Partial
+            else -> ScanState.Scanning
+        }
+
+        val message = when {
+            validation.errors.isNotEmpty() -> "Review highlighted fields"
+            result is OcrResult.Partial -> "Hold steady for clearer capture"
+            else -> "Data captured"
+        }
+
+        _status.value = ScanStatus(
+            state = baseStatus,
+            message = message,
+            confidence = when (result) {
+                is OcrResult.Success -> result.confidence
+                is OcrResult.Partial -> result.confidence
+                else -> 0f
+            },
+            frames = when (result) {
+                is OcrResult.Success -> result.frames
+                is OcrResult.Partial -> result.frames
+                else -> 0
+            }
+        )
+
+        if (autoPersist && validation.errors.isEmpty()) {
+            persistIfUnique(validation, result as OcrResult.Success)
+        }
+    }
+
+    private fun persistIfUnique(validation: ValidationResult, result: OcrResult.Success) {
+        val serialConfidence = validation.sanitized["sirimSerialNo"]
+        if (serialConfidence == null || serialConfidence.value.isBlank()) {
+            _status.value = _status.value.copy(state = ScanState.Error, message = "Serial number missing; manual review required")
+            return
+        }
+        val sanitizedCopy = validation.sanitized.mapValues { it.value.copy() }
+        val pending = PendingRecord(
+            serial = serialConfidence.value,
+            fields = sanitizedCopy,
+            imageBytes = result.bitmap?.toJpegByteArray(),
+            timestamp = System.currentTimeMillis(),
+            captureConfidence = result.confidence
+        )
+        appScope.launch {
+            val duplicate = repository.findBySerial(pending.serial)
+            if (duplicate != null) {
+                _status.value = _status.value.copy(state = ScanState.Duplicate, message = "Duplicate serial detected: ${pending.serial}")
+                return@launch
+            }
+            if (_batchMode.value) {
+                _batchQueue.update { it + pending }
+                val queueSize = _batchQueue.value.size
+                _status.value = _status.value.copy(
+                    state = ScanState.Ready,
+                    message = "Queued ${pending.serial} ($queueSize pending)",
+                    confidence = pending.captureConfidence
+                )
+            } else {
+                persistPending(pending)
+            }
+        }
+    }
+
+    private suspend fun persistPending(pending: PendingRecord) {
+        val imagePath = pending.imageBytes?.let { repository.persistImage(it) }
+        val record = pending.toRecord(imagePath)
+        val id = repository.upsert(record)
+        _lastResultId.value = id
+        _status.value = _status.value.copy(
+            state = ScanState.Persisted,
+            message = "Record saved (${pending.serial})",
+            confidence = pending.captureConfidence
+        )
+    }
+
+    companion object {
+        fun Factory(
+            repository: SirimRepository,
+            analyzer: LabelAnalyzer,
+            appScope: CoroutineScope
+        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return ScannerViewModel(repository, analyzer, appScope) as T
+            }
+        }
+    }
+}
+
+data class ScanStatus(
+    val state: ScanState = ScanState.Idle,
+    val message: String = "",
+    val confidence: Float = 0f,
+    val frames: Int = 0
+)
+
+enum class ScanState {
+    Idle,
+    Scanning,
+    Partial,
+    Ready,
+    Persisted,
+    Duplicate,
+    Error
+}
+
+data class BatchUiState(
+    val enabled: Boolean = false,
+    val queued: List<BatchQueueItem> = emptyList()
+)
+
+data class BatchQueueItem(
+    val serial: String,
+    val capturedAt: Long,
+    val confidence: Float
+)
+
+private data class PendingRecord(
+    val serial: String,
+    val fields: Map<String, FieldConfidence>,
+    val imageBytes: ByteArray?,
+    val timestamp: Long,
+    val captureConfidence: Float
+) {
+    fun toRecord(imagePath: String?): SirimRecord = SirimRecord(
+        sirimSerialNo = fields["sirimSerialNo"]?.value.orEmpty(),
+        batchNo = fields["batchNo"]?.value.orEmpty(),
+        brandTrademark = fields["brandTrademark"]?.value.orEmpty(),
+        model = fields["model"]?.value.orEmpty(),
+        type = fields["type"]?.value.orEmpty(),
+        rating = fields["rating"]?.value.orEmpty(),
+        size = fields["size"]?.value.orEmpty(),
+        imagePath = imagePath,
+        createdAt = timestamp,
+        isVerified = false
+    )
+}

--- a/app/src/main/java/com/sirim/scanner/ui/theme/Color.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/theme/Color.kt
@@ -1,0 +1,7 @@
+package com.sirim.scanner.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val BrandPrimary = Color(0xFF0047AB)
+val BrandSecondary = Color(0xFF00A896)
+val BrandSurface = Color(0xFFF1F3F6)

--- a/app/src/main/java/com/sirim/scanner/ui/theme/Theme.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/theme/Theme.kt
@@ -1,0 +1,35 @@
+package com.sirim.scanner.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColors = darkColorScheme(
+    primary = BrandPrimary,
+    secondary = BrandSecondary,
+    surface = BrandSurface,
+    background = BrandSurface
+)
+
+private val LightColors = lightColorScheme(
+    primary = BrandPrimary,
+    secondary = BrandSecondary,
+    surface = BrandSurface,
+    background = BrandSurface
+)
+
+@Composable
+fun SirimScannerTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colors = if (useDarkTheme) DarkColors else LightColors
+
+    MaterialTheme(
+        colorScheme = colors,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/sirim/scanner/ui/theme/Type.kt
+++ b/app/src/main/java/com/sirim/scanner/ui/theme/Type.kt
@@ -1,0 +1,5 @@
+package com.sirim.scanner.ui.theme
+
+import androidx.compose.material3.Typography
+
+val Typography = Typography()

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#F1F3F6" />
+</shape>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#0047AB"
+        android:pathData="M18,18h72v72h-72z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M34,42h40v8h-40z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M34,56h40v8h-40z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M34,70h24v8h-24z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-hdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-hdpi/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-hdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-hdpi/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-mdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-mdpi/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-mdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-mdpi/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-xhdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-xhdpi/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-xhdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-xhdpi/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-xxhdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-xxhdpi/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-xxxhdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-xxxhdpi/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="brand_primary">#0047AB</color>
+    <color name="brand_secondary">#00A896</color>
+    <color name="brand_surface">#F1F3F6</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">SIRIM Scanner</string>
+    <string name="login_error">Invalid username or password</string>
+    <string name="camera_permission_required">Camera permission required</string>
+    <string name="export_success">Export completed</string>
+    <string name="export_failure">Export failed</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.SirimScanner" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="database" path="/" />
+    <include domain="sharedpref" path="/" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <include domain="database" path="/" />
+        <include domain="file" path="/" />
+    </cloud-backup>
+</data-extraction-rules>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path
+        name="exports"
+        path="." />
+    <files-path
+        name="captures"
+        path="captured/" />
+</paths>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.application") version "8.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("kotlin-kapt") version "1.9.23" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "SirimScanner"
+include(":app")


### PR DESCRIPTION
## Summary
- introduce a Tess-two backed fallback inside `LabelAnalyzer`, wire it up via the app container, and document the `eng.traineddata` setup
- extend the scanner workflow with batch-mode queuing, persistence safeguards, and Compose controls for queue review
- enhance record management filters/duplicate handling and generate timestamped multi-sheet exports stored under dated folders

## Testing
- not run (Android tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68db51656e948325a845d0b50ba009b8